### PR TITLE
Fix MIME type for .mjs files

### DIFF
--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -47,6 +47,7 @@ public class WebInterface {
                 ".html", "text/html",
                 ".css", "text/css",
                 ".js", "application/javascript",
+                ".mjs", "application/javascript",
                 ".png", "image/png",
                 ".webmanifest", "application/manifest+json"
         );


### PR DESCRIPTION
My bad for not testing. But now I will!

My browser refused to load the JS because of the fallback MIME type. So currently it's broken.