### PR TITLE
Add structured message format for WebSocket traffic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "minecraft-web-chat",
       "devDependencies": {
         "jsdom": "^25.0.1",
         "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "minecraft-web-chat",
+  "displayName": "minecraft-web-chat",
   "scripts": {
     "test": "vitest"
   },

--- a/src/client/java/dev/creesch/WebchatClient.java
+++ b/src/client/java/dev/creesch/WebchatClient.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 public class WebchatClient implements ClientModInitializer {
     private static final NamedLogger LOGGER = new NamedLogger("web-chat");
     private WebInterface webInterface;
+    private final Gson gson = new Gson();
 
     /**
      * Processes both chat and game messages, converting them to the appropriate format
@@ -51,12 +52,9 @@ public class WebchatClient implements ClientModInitializer {
                 minecraftVersion
         );
 
-        Gson gson = new GsonBuilder()
-                .setPrettyPrinting()
-                .create();
-
-        LOGGER.info(gson.toJson(chatMessage));
-        webInterface.broadcastMessage(minecraftChatJson);
+        String jsonChatMessage = gson.toJson(chatMessage);
+        LOGGER.info(jsonChatMessage);
+        webInterface.broadcastMessage(jsonChatMessage);
     }
 
     @Override

--- a/src/client/java/dev/creesch/WebchatClient.java
+++ b/src/client/java/dev/creesch/WebchatClient.java
@@ -1,20 +1,63 @@
 package dev.creesch;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import dev.creesch.config.ModConfig;
+import dev.creesch.model.WebsocketJsonMessage;
+import dev.creesch.model.WebsocketJsonMessage.ChatServerInfo;
+import dev.creesch.util.MinecraftServerIdentifier;
 import dev.creesch.util.NamedLogger;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.ClickEvent;
 
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
+import java.time.Clock;
+import java.time.Instant;
+
 public class WebchatClient implements ClientModInitializer {
     private static final NamedLogger LOGGER = new NamedLogger("web-chat");
     private WebInterface webInterface;
+
+    /**
+     * Processes both chat and game messages, converting them to the appropriate format
+     * and broadcasting them to connected web clients.
+     *
+     * @param message The Minecraft text message to process
+     * @param client The Minecraft client instance
+     */
+    private void handleMessage(Text message, MinecraftClient client) {
+        if (client.world == null) {
+            return;
+        }
+
+        // Can't use GSON for Text serialization easily, using Minecraft's own serializer.
+        String minecraftChatJson = Text.Serialization.toJsonString(message, client.world.getRegistryManager());
+        // Explicitly use UTC time for consistency across different timezones
+        long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
+        ChatServerInfo serverInfo = MinecraftServerIdentifier.getCurrentServerInfo();
+        String minecraftVersion = SharedConstants.getGameVersion().getName();
+
+        WebsocketJsonMessage chatMessage = WebsocketJsonMessage.createChatMessage(
+                timestamp,
+                serverInfo,
+                minecraftChatJson,
+                minecraftVersion
+        );
+
+        Gson gson = new GsonBuilder()
+                .setPrettyPrinting()
+                .create();
+
+        LOGGER.info(gson.toJson(chatMessage));
+        webInterface.broadcastMessage(minecraftChatJson);
+    }
 
     @Override
     public void onInitializeClient() {
@@ -25,31 +68,16 @@ public class WebchatClient implements ClientModInitializer {
         LOGGER.info("web chat loaded");
 
         // Chat messages from users.
-        // TODO: extract more information, put in object serialize to json
         ClientReceiveMessageEvents.CHAT.register((message, signedMessage, sender, params, receptionTimestamp) -> {
-            MinecraftClient client = MinecraftClient.getInstance();
-            if (client.world == null) {
-                return;
-            }
-
-            String json = Text.Serialization.toJsonString(message, client.world.getRegistryManager());
-            LOGGER.info("Got chat message as JSON: {}", json);
-            webInterface.broadcastMessage(json);
+            handleMessage(message, MinecraftClient.getInstance());
         });
 
         // System messages (joins, leaves, deaths, etc.)
-        // TODO: extract more information, put in object serialize to json
         ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
-            MinecraftClient client = MinecraftClient.getInstance();
-            if (client.world == null) {
-                return;
-            }
-
-            String json = Text.Serialization.toJsonString(message, client.world.getRegistryManager());
-            LOGGER.info("Got game message as JSON: {}", json);
-            webInterface.broadcastMessage(json);
+            handleMessage(message, MinecraftClient.getInstance());
         });
 
+        // When joining a server, send a clickable message with the web interface URL
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
             client.execute(() -> {
                 if (client.player == null) {
@@ -67,7 +95,7 @@ public class WebchatClient implements ClientModInitializer {
             });
         });
 
-        // Properly handle minecraft shutting down
+        // Properly handle minecraft shutting down.
         ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
             if (webInterface == null) {
                 return;

--- a/src/client/java/dev/creesch/model/WebsocketJsonMessage.java
+++ b/src/client/java/dev/creesch/model/WebsocketJsonMessage.java
@@ -14,7 +14,6 @@ public class WebsocketJsonMessage {
     private long timestamp;
     private ChatServerInfo server;
     private MessageType type;
-    @SerializedName("minecraftVersion")
     private String minecraftVersion;
     private Object payload;
 
@@ -34,7 +33,13 @@ public class WebsocketJsonMessage {
     }
 
     // Private constructor to force use of factory methods
-    private WebsocketJsonMessage(long timestamp, ChatServerInfo server, MessageType type, Object payload, String minecraftVersion) {
+    private WebsocketJsonMessage(
+            long timestamp,
+            ChatServerInfo server,
+            MessageType type,
+            Object payload,
+            String minecraftVersion
+    ) {
         this.timestamp = timestamp;
         this.server = server;
         this.type = type;
@@ -42,10 +47,12 @@ public class WebsocketJsonMessage {
         this.minecraftVersion = minecraftVersion;
     }
 
-    public static WebsocketJsonMessage createChatMessage(long timestamp,
-                                                         ChatServerInfo server,
-                                                         String message,
-                                                         String minecraftVersion) {
+    public static WebsocketJsonMessage createChatMessage(
+            long timestamp,
+            ChatServerInfo server,
+            String message,
+            String minecraftVersion
+    ) {
         // Because we need to serialize the Text object with mine
         JsonElement parsedMessage = JsonParser.parseString(message);
         return new WebsocketJsonMessage(timestamp, server, MessageType.CHAT_MESSAGE, parsedMessage, minecraftVersion);

--- a/src/client/java/dev/creesch/model/WebsocketJsonMessage.java
+++ b/src/client/java/dev/creesch/model/WebsocketJsonMessage.java
@@ -1,0 +1,53 @@
+package dev.creesch.model;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebsocketJsonMessage {
+    private long timestamp;
+    private ChatServerInfo server;
+    private MessageType type;
+    @SerializedName("minecraftVersion")
+    private String minecraftVersion;
+    private Object payload;
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatServerInfo {
+        private String name;
+        private String identifier;
+    }
+
+
+    public enum MessageType {
+        @SerializedName("chatMessage")
+        CHAT_MESSAGE
+    }
+
+    // Private constructor to force use of factory methods
+    private WebsocketJsonMessage(long timestamp, ChatServerInfo server, MessageType type, Object payload, String minecraftVersion) {
+        this.timestamp = timestamp;
+        this.server = server;
+        this.type = type;
+        this.payload = payload;
+        this.minecraftVersion = minecraftVersion;
+    }
+
+    public static WebsocketJsonMessage createChatMessage(long timestamp,
+                                                         ChatServerInfo server,
+                                                         String message,
+                                                         String minecraftVersion) {
+        // Because we need to serialize the Text object with mine
+        JsonElement parsedMessage = JsonParser.parseString(message);
+        return new WebsocketJsonMessage(timestamp, server, MessageType.CHAT_MESSAGE, parsedMessage, minecraftVersion);
+    }
+}

--- a/src/client/java/dev/creesch/util/MinecraftServerIdentifier.java
+++ b/src/client/java/dev/creesch/util/MinecraftServerIdentifier.java
@@ -1,0 +1,85 @@
+package dev.creesch.util;
+
+import dev.creesch.model.WebsocketJsonMessage;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.server.integrated.IntegratedServer;
+import net.minecraft.util.WorldSavePath;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+/**
+ * Utility class for identifying Minecraft servers and worlds.
+ * Provides consistent identification for singleplayer (LAN) worlds and multiplayer servers.
+ */
+public class MinecraftServerIdentifier {
+    private static final NamedLogger LOGGER = new NamedLogger("web-chat");
+    /**
+     * Default server info returned when not connected to any world/server.
+     * Should not happen in the current mod setup. But better to account for it.
+     * Also allows for sending messages in the future when a user is not connected to a server.
+     */
+    private static final MinecraftClient client = MinecraftClient.getInstance();
+    private static final WebsocketJsonMessage.ChatServerInfo DISCONNECTED =
+            new WebsocketJsonMessage.ChatServerInfo("Disconnected", "disconnected");
+
+    /**
+     * Gets information about the current server or world the player is connected to.
+     *
+     * For singleplayer worlds (including LAN):
+     * - name: The world save folder name
+     * - identifier: UUID generated from relative path to world save
+     *
+     * For multiplayer servers:
+     * - name: Server name or address if name is not available
+     * - identifier: UUID generated from server address
+     *
+     * @return ChatServerInfo containing the name and unique identifier of the current server/world.
+     *         Returns DISCONNECTED if not connected to any world or server.
+     */
+    public static WebsocketJsonMessage.ChatServerInfo getCurrentServerInfo() {
+
+        // World is null, so we can't be on a minecraft server of any kind.
+        if (client.world == null) {
+            return DISCONNECTED;
+        }
+
+        // For single player the most straightforward method seems to be use the relative safe path.
+        // Even more unique would be the absolute path.
+        // But that would potentially mess with people restoring minecraft on a different computer.
+        if (client.isInSingleplayer()) {
+            IntegratedServer server = client.getServer();
+            if (server == null) {
+                return DISCONNECTED;
+            }
+
+
+            Path minecraftDir = client.runDirectory.toPath();
+            LOGGER.info("Minecraft dir: {}", minecraftDir);
+            Path savePath = server.getSavePath(WorldSavePath.ROOT);
+            LOGGER.info("savePath : {}", savePath);
+
+            String worldName = savePath.getFileName().toString();
+            LOGGER.info("worldName : {}", worldName);
+            String rawIdentifier = minecraftDir.relativize(savePath).toString();
+            LOGGER.info("rawIdentifier : {}", rawIdentifier);
+
+            return new WebsocketJsonMessage.ChatServerInfo(
+                    worldName,
+                    UUID.nameUUIDFromBytes(rawIdentifier.getBytes()).toString()
+            );
+
+        } else {
+            ServerInfo serverInfo = client.getCurrentServerEntry();
+            if (serverInfo == null) {
+                return DISCONNECTED;
+            }
+
+            return new WebsocketJsonMessage.ChatServerInfo(
+                    serverInfo.name != null ? serverInfo.name : serverInfo.address,
+                    UUID.nameUUIDFromBytes(serverInfo.address.getBytes()).toString()
+            );
+        }
+    }
+}

--- a/src/client/java/dev/creesch/util/MinecraftServerIdentifier.java
+++ b/src/client/java/dev/creesch/util/MinecraftServerIdentifier.java
@@ -14,7 +14,6 @@ import java.util.UUID;
  * Provides consistent identification for singleplayer (LAN) worlds and multiplayer servers.
  */
 public class MinecraftServerIdentifier {
-    private static final NamedLogger LOGGER = new NamedLogger("web-chat");
     /**
      * Default server info returned when not connected to any world/server.
      * Should not happen in the current mod setup. But better to account for it.
@@ -74,7 +73,7 @@ public class MinecraftServerIdentifier {
 
             // It is very unlikely that label is null for servers. But just in case fall back to the server address.
             String serverName = serverInfo.label != null ? serverInfo.label.getString() : serverInfo.address;
-            String serverIdentifier = UUID.nameUUIDFromBytes((serverName + serverInfo.address).getBytes()).toString();
+            String serverIdentifier = UUID.nameUUIDFromBytes(serverInfo.address.getBytes()).toString();
             return new WebsocketJsonMessage.ChatServerInfo(
                     serverName,
                     serverIdentifier

--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -6,49 +6,64 @@ body {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    font-size: 16px; /* Base font size for rem scaling */
 }
 
 #container {
     flex: 1;
     display: flex;
     flex-direction: column;
-    margin: 1rem;
+    margin: 0.5rem;
     background-color: rgba(0, 0, 0, 0.3);
-    border-radius: 8px;
+    border-radius: 0.3rem;
     overflow: hidden;
 }
 
 #messages {
     flex: 1;
     overflow-y: auto;
-    padding: 20px;
+    padding: 1rem;
     display: flex;
     flex-direction: column-reverse; /* Makes new messages appear at bottom */
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.2) rgba(0, 0, 0, 0.1);
+    scrollbar-gutter: stable;
 }
 
 .message {
-    margin: 4px 0;
-    padding: 4px 0;
+    margin: 0.25rem 0;
+    padding: 0.25rem 0;
     word-wrap: break-word;
 }
 
+.message a {
+    color: #5555FF;
+    text-decoration: none;
+}
+
+.message-time {
+    color: #b7b7b7; 
+    font-size: 0.75rem;
+    margin-right: 0.3rem;
+}
+
 #input-area {
-    padding: 20px;
+    padding: 1rem;
     background-color: rgba(0, 0, 0, 0.2);
     display: flex;
-    gap: 10px;
+    gap: 0.5rem;
 }
 
 #messageInput {
     flex: 1;
-    padding: 10px;
+    padding: 0.5rem;
     border: none;
-    border-radius: 4px;
+    border-radius: 0.3rem;
     background-color: rgba(255, 255, 255, 0.1);
     color: white;
-    font-size: 16px;
+    font-size: 1rem;
     resize: none;
-    line-height: 20px;
+    line-height: 1.25rem;
     font-family: inherit;
 }
 
@@ -58,13 +73,13 @@ body {
 }
 
 button {
-    padding: 10px 20px;
+    padding: 0.6rem 1.5rem;
     border: none;
-    border-radius: 4px;
+    border-radius: 0.3rem;
     background-color: #4CAF50;
     color: white;
     cursor: pointer;
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 button:hover {
@@ -73,12 +88,12 @@ button:hover {
 
 #status {
     position: fixed;
-    top: 10px;
-    right: 10px;
-    padding: 5px 10px;
-    border-radius: 4px;
+    top: 1rem; 
+    right: 1rem; 
+    padding: 0.3rem 0.6rem; 
+    border-radius: 0.3rem;
     background-color: rgba(0, 0, 0, 0.5);
-    font-size: 14px;
+    font-size: 0.8rem;
 }
 
 .status-connected {
@@ -87,16 +102,4 @@ button:hover {
 
 .status-disconnected {
     color: #f44336;
-}
-
-#messages {
-    scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.2) rgba(0, 0, 0, 0.1);
-
-    scrollbar-gutter: stable;
-}
-
-.message a {
-    color: #5555FF;
-    text-decoration: none;
 }

--- a/src/client/resources/web/js/message_types.mjs
+++ b/src/client/resources/web/js/message_types.mjs
@@ -1,0 +1,62 @@
+// @ts-check
+'use strict';
+
+/**
+ * Server information matching ChatServerInfo on server
+ * @typedef {Object} ServerInfo
+ * @property {string} name
+ * @property {string} identifier
+ */
+
+/**
+ * Base message interface matching WebsocketJsonMessage on server
+ * @typedef {Object} BaseModServerMessage
+ * @property {number} timestamp
+ * @property {ServerInfo} server
+ * @property {string} minecraftVersion
+ */
+
+/**
+ * Chat message from Minecraft
+ * @typedef {Object} ChatMessage
+ * @property {'chatMessage'} type
+ * @property {import('./message_parsing.mjs').Component} payload
+ */
+
+/**
+ * @typedef {BaseModServerMessage & ChatMessage} ModServerMessage
+ */
+
+/**
+ * Minimal type guard for TypeScript type narrowing.
+ * No complete validation because the server (mod) and client (this) are tightly coupled in one package.
+ * @param {unknown} message
+ * @returns {message is ModServerMessage}
+ */
+export function isModServerMessage(message) {
+    if (typeof message !== 'object' || message === null) {
+        return false;
+    }
+    if (!('type' in message)) {
+        return false;
+    }
+
+    /** @type {any} */
+    const messageWithType = message;
+    return messageWithType.type === 'chatMessage';
+}
+
+/**
+ * Parse message from WebSocket
+ * @param {string} rawMessage
+ * @returns {ModServerMessage}
+ */
+export function parseModServerMessage(rawMessage) {
+    const message = JSON.parse(rawMessage);
+    
+    if (!isModServerMessage(message)) {
+        throw new Error('Invalid message type');
+    }
+    
+    return message;
+}

--- a/src/client/resources/web/js/message_types.mjs
+++ b/src/client/resources/web/js/message_types.mjs
@@ -41,9 +41,7 @@ export function isModServerMessage(message) {
         return false;
     }
 
-    /** @type {any} */
-    const messageWithType = message;
-    return messageWithType.type === 'chatMessage';
+    return message.type === 'chatMessage';
 }
 
 /**

--- a/src/client/resources/web/js/util.mjs
+++ b/src/client/resources/web/js/util.mjs
@@ -49,3 +49,32 @@ export function faviconCounter(count) {
         };
     });
 }
+
+/**
+ * Format a timestamp into a human readable format
+ * @param {number} timestamp - Timestamp in milliseconds
+ * @returns {{ timeString: string, fullDateTime: string }}
+ */
+export function formatTimestamp(timestamp) {
+    const date = new Date(timestamp);
+    
+    // Format HH:MM for display
+    const timeString = date.toLocaleTimeString([], { 
+        hour: '2-digit', 
+        minute: '2-digit',
+        hour12: false 
+    });
+    
+    // Full date and time for tooltip
+    const fullDateTime = date.toLocaleString([], {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false
+    });
+    
+    return { timeString, fullDateTime };
+}

--- a/src/main/java/dev/creesch/Webchat.java
+++ b/src/main/java/dev/creesch/Webchat.java
@@ -6,12 +6,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Webchat implements ModInitializer {
-	public static final String MOD_ID = "web-chat";
-	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    public static final String MOD_ID = "web-chat";
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-	@Override
-	public void onInitialize() {
-		// Nothing to do here, since this is a client only mod everything can be found `src/client/java`
-		LOGGER.info(MOD_ID);
-	}
+    @Override
+    public void onInitialize() {
+        // Nothing to do here, since this is a client only mod everything can be found `src/client/java`
+        LOGGER.info(MOD_ID);
+    }
 }


### PR DESCRIPTION
Fixes #22
Fixes #6

Java side:
- `WebsocketJsonMessage` class for the message format.
- `MinecraftServerIdentifier` class to properly identify the "server" name and a unique identifier. 

Front-end:
- New `message_types.mjs` module containing the front-end implementation of the new structured messages. 
- Reworked `chat.mjs` to handle the new structured message format. 
   - This includes handling the new timestamps. This includes using them for error messages. 
- Added: utility function to create timestamps. 
- Sneaky refactor of the CSS to be more consistently use rem. 
- Removed functionality for stored messages from the front-end code. It didn't make sense to me to try and migrate these somehow and the next PR from me will very likely be tackling #3



Example message

```
{
    "timestamp": 1734794189937,
    "server": {
        "name": "Tildes MC Survival",
        "identifier": "4d311f91-6a27-31a3-b76d-3efe21dda823"
    },
    "type": "chatMessage",
    "minecraftVersion": "1.21.1",
    "payload": {
        "translate": "%s",
        "with": [
            {
                "text": "\u003c",
                "extra": [
                    {
                        "text": "creesch",
                        "color": "#0099CC"
                    },
                    {
                        "text": "\u003e ",
                        "extra": [
                            "Testing something with timestamp"
                        ]
                    }
                ]
            }
        ]
    }
}
```

Screenshot: 

![image](https://github.com/user-attachments/assets/685901ca-e142-4241-b982-7bb3173bd54c)
