### PR TITLE
Setup editorconfig and gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# top-most EditorConfig file
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# By default spaces for indentation, 4 of them.
+indent_style = space
+indent_size = 4
+
+# Config files can have 2 of them.
+[*.{json,webmanifest,yml,yaml}]
+indent_size = 2
+
+# Markdown files might need their trailing whitespaces for markup
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
-#
-# https://help.github.com/articles/dealing-with-line-endings/
-#
-# Linux start script should use lf
-/gradlew        text eol=lf
+# Default to LF line endings
+* text=auto eol=lf
 
-# These are Windows script files and should use crlf
-*.bat           text eol=crlf
+# Windows scripts need CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
 
+# Linux scripts need LF
+gradlew text eol=lf


### PR DESCRIPTION
Part of #17 sets up the repository with some (I think) sensible defaults. Did debate also using four spaces for json and yaml but there the convention mostly is two spaces so I went with that. 