### PR TITLE
Implement server playerlist with head textures

### DIFF
--- a/src/client/java/dev/creesch/model/PlayerListInfoEntry.java
+++ b/src/client/java/dev/creesch/model/PlayerListInfoEntry.java
@@ -1,0 +1,13 @@
+package dev.creesch.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PlayerListInfoEntry {
+    private String playerId;
+    private String playerName;
+    private String playerDisplayName;
+    private String playerTextureUrl;
+}

--- a/src/client/java/dev/creesch/model/WebsocketJsonMessage.java
+++ b/src/client/java/dev/creesch/model/WebsocketJsonMessage.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -29,7 +31,9 @@ public class WebsocketJsonMessage {
         @SerializedName("serverConnectionState")
         SERVER_CONNECTION_STATE,
         @SerializedName("historyMetaData")
-        HISTORY_META_DATA
+        HISTORY_META_DATA,
+        @SerializedName("serverPlayerList")
+        SERVER_PLAYER_LIST
     }
 
     /**
@@ -91,5 +95,14 @@ public class WebsocketJsonMessage {
             .build();
 
         return new WebsocketJsonMessage(timestamp, server, MessageType.HISTORY_META_DATA, historyMetaDataPayload, minecraftVersion);
+    }
+
+    public static WebsocketJsonMessage createServerPlayerListMessage (
+        long timestamp,
+        ChatServerInfo server,
+        List<PlayerListInfoEntry> playerList,
+        String minecraftVersion
+    ) {
+        return new WebsocketJsonMessage(timestamp, server, MessageType.SERVER_PLAYER_LIST, playerList, minecraftVersion);
     }
 }

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -3,20 +3,30 @@ package dev.creesch.model;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
+import com.google.gson.JsonParser;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
 import dev.creesch.config.ModConfig;
 import dev.creesch.util.MinecraftServerIdentifier;
+import dev.creesch.util.NamedLogger;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.text.Text;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.regex.Pattern;
 
 public class WebsocketMessageBuilder {
     private static final Gson gson = new Gson();
+    private static final NamedLogger LOGGER = new NamedLogger("web-chat");
 
     /**
      * Processes both chat and game messages, converting them to the appropriate format
@@ -65,7 +75,7 @@ public class WebsocketMessageBuilder {
      *
      * @param message The minecraft text message to process
      * @param client The Minecraft client instance
-     * @return True if the message is a ping, false otherwise   
+     * @return True if the message is a ping, false otherwise
      */
     private static boolean isPing(Text message, MinecraftClient client) {
         String messageString = message.getString();
@@ -77,10 +87,14 @@ public class WebsocketMessageBuilder {
                 return true;
             }
 
-            String displayName = client.player.getDisplayName().getString();
-            if (pingPattern(displayName).matcher(messageString).find()) {
-                return true;
+            if (client.player.getDisplayName() != null) {
+                String displayName = client.player.getDisplayName().getString();
+                if (pingPattern(displayName).matcher(messageString).find()) {
+                    return true;
+                }
             }
+
+
         }
 
         for (String pingKeyword : config.pingKeywords) {
@@ -94,7 +108,7 @@ public class WebsocketMessageBuilder {
 
     /**
      * Creates a pattern for a ping keyword.
-     * 
+     *
      * @param pingKeyword The keyword to ping for
      * @return The pattern for the ping keyword
      */
@@ -193,6 +207,91 @@ public class WebsocketMessageBuilder {
             serverInfo,
             oldestTimestamp,
             moreHistoryAvailable,
+            minecraftVersion
+        );
+    }
+
+    private static final Pattern MINECRAFT_TEXTURE_URL_PATTERN = Pattern.compile("^https?://textures\\.minecraft\\.net/texture/.+");
+
+    private static String getPlayerTextureUrl(GameProfile profile) {
+        Collection<Property> textures = profile.getProperties().get("textures");
+        if (textures.isEmpty()) {
+            return "unknown";
+        }
+
+        // Generally there should only be one texture.
+        // But, it is apparently possible for modified servers and such to add multiple.
+        // Mojang signs textures, but that seems overkill.
+        // Instead, simply grab the first texture that is minecraft hosted. Fingers crossed there aren't multiple hostnames for textures.
+        for (Property property : textures) {
+            try {
+                String decodedValue = new String(Base64.getDecoder().decode(property.value()), StandardCharsets.UTF_8);
+                JsonObject textureJson = JsonParser.parseString(decodedValue).getAsJsonObject();
+                JsonObject texturesObj = textureJson.getAsJsonObject("textures");
+
+                if (texturesObj.has("SKIN")) {
+                    String textureURL = texturesObj.getAsJsonObject("SKIN")
+                    .get("url")
+                    .getAsString();
+
+                    if (MINECRAFT_TEXTURE_URL_PATTERN.matcher(textureURL).matches()) {
+                        // Replace http with https to ensure secure URLs
+                        textureURL = textureURL.replaceFirst("^http://", "https://");
+                        return textureURL;
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.error("Error decoding skin texture for player {}", profile.getName(), e);
+            }
+        }
+
+        return "unknown";
+    }
+
+     /**
+     * Uses the networkHandler to fetch a playerlist and create a ServerPlayerListMessage.
+     *
+     * @param client MinecraftClient
+     */
+    public static WebsocketJsonMessage createPlayerList(MinecraftClient client) {
+        ClientPlayNetworkHandler networkHandler = client.getNetworkHandler();
+
+        List<PlayerListInfoEntry> playerList = new ArrayList<>();
+        if (networkHandler != null) {
+            networkHandler.getPlayerList().forEach(player -> {
+                GameProfile profile = player.getProfile(); // Contains UUID and name
+                String playerId = profile.getId().toString();
+                String playerName = profile.getName();
+                String playerDisplayName = player.getDisplayName() != null ? player.getDisplayName().getString() : playerName;
+
+                // To get the texture we need to digg a little bit deeper.
+                // Note: This retrieves the texture URL. In theory, it is possible to fetch player textures from minecraft.
+                // In practice this is a messy afair because of how texture loading works. So it is easier to let the web client.
+                // Fetch the texture from mojang directly and cut the head out of it.
+                String playerTextureUrl = getPlayerTextureUrl(profile);
+
+                PlayerListInfoEntry playerInfo = PlayerListInfoEntry.builder()
+                    .playerId(playerId)
+                    .playerName(playerName)
+                    .playerDisplayName(playerDisplayName)
+                    .playerTextureUrl(playerTextureUrl)
+                    .build();
+
+                playerList.add(playerInfo);
+            });
+        } else {
+            return null;
+        }
+
+        // Explicitly use UTC time for consistency across different timezones
+        long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
+        WebsocketJsonMessage.ChatServerInfo serverInfo = MinecraftServerIdentifier.getCurrentServerInfo();
+        String minecraftVersion = SharedConstants.getGameVersion().getName();
+
+        return WebsocketJsonMessage.createServerPlayerListMessage(
+            timestamp,
+            serverInfo,
+            playerList,
             minecraftVersion
         );
     }

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -229,8 +229,8 @@ public class WebsocketMessageBuilder {
 
                 if (texturesObj.has("SKIN")) {
                     String textureURL = texturesObj.getAsJsonObject("SKIN")
-                    .get("url")
-                    .getAsString();
+                        .get("url")
+                        .getAsString();
 
                     if (MINECRAFT_TEXTURE_URL_PATTERN.matcher(textureURL).matches()) {
                         // Replace http with https to ensure secure URLs

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -255,31 +255,31 @@ public class WebsocketMessageBuilder {
         ClientPlayNetworkHandler networkHandler = client.getNetworkHandler();
 
         List<PlayerListInfoEntry> playerList = new ArrayList<>();
-        if (networkHandler != null) {
-            networkHandler.getPlayerList().forEach(player -> {
-                GameProfile profile = player.getProfile(); // Contains UUID and name
-                String playerId = profile.getId().toString();
-                String playerName = profile.getName();
-                String playerDisplayName = player.getDisplayName() != null ? player.getDisplayName().getString() : playerName;
 
-                // To get the texture we need to digg a little bit deeper.
-                // Note: This retrieves the texture URL. In theory, it is possible to fetch player textures from minecraft.
-                // In practice this is a messy afair because of how texture loading works. So it is easier to let the web client.
-                // Fetch the texture from mojang directly and cut the head out of it.
-                String playerTextureUrl = getPlayerTextureUrl(profile);
-
-                PlayerListInfoEntry playerInfo = PlayerListInfoEntry.builder()
-                    .playerId(playerId)
-                    .playerName(playerName)
-                    .playerDisplayName(playerDisplayName)
-                    .playerTextureUrl(playerTextureUrl)
-                    .build();
-
-                playerList.add(playerInfo);
-            });
-        } else {
+        if (networkHandler == null) {
             return null;
         }
+        networkHandler.getPlayerList().forEach(player -> {
+            GameProfile profile = player.getProfile(); // Contains UUID and name
+            String playerId = profile.getId().toString();
+            String playerName = profile.getName();
+            String playerDisplayName = player.getDisplayName() != null ? player.getDisplayName().getString() : playerName;
+
+            // To get the texture we need to digg a little bit deeper.
+            // Note: This retrieves the texture URL. In theory, it is possible to fetch player textures from minecraft.
+            // In practice this is a messy afair because of how texture loading works. So it is easier to let the web client.
+            // Fetch the texture from mojang directly and cut the head out of it.
+            String playerTextureUrl = getPlayerTextureUrl(profile);
+
+            PlayerListInfoEntry playerInfo = PlayerListInfoEntry.builder()
+                .playerId(playerId)
+                .playerName(playerName)
+                .playerDisplayName(playerDisplayName)
+                .playerTextureUrl(playerTextureUrl)
+                .build();
+
+            playerList.add(playerInfo);
+        });
 
         // Explicitly use UTC time for consistency across different timezones
         long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -93,8 +93,6 @@ public class WebsocketMessageBuilder {
                     return true;
                 }
             }
-
-
         }
 
         for (String pingKeyword : config.pingKeywords) {

--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -230,9 +230,8 @@ body {
     #status {
         top: 0.5rem;
         bottom: auto;
-        left: 50%;
-        transform: translateX(-50%);
-        width: calc(100% - 1rem);
-        max-width: 400px;
+        left: 0.5rem;
+        right: 0.5rem;
+        width: auto;
     }
 }

--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -3,20 +3,78 @@ body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: #2c2c2c;
     color: #ffffff;
-    display: flex;
-    flex-direction: column;
     height: 100vh;
     font-size: 16px; /* Base font size for rem scaling */
+    overflow: hidden;
 }
 
 #container {
+    height: 100vh;
+    display: flex;
+    padding: 0.5rem;
+    gap: 0.5rem;
+    box-sizing: border-box;
+}
+
+#chat-area {
     flex: 1;
     display: flex;
     flex-direction: column;
-    margin: 0.5rem;
     background-color: rgba(0, 0, 0, 0.3);
     border-radius: 0.3rem;
     overflow: hidden;
+}
+
+#player-list-container {
+    width: 250px;
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 0.3rem;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    /* Add margin at bottom to make room for fixed status bar */
+    margin-bottom: 2.1rem;
+}
+
+#player-list-container h2 {
+    margin: 0;
+    padding: 1rem;
+    font-size: 1.1rem;
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+#player-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.5rem;
+    overflow-y: auto;
+    flex: 1;
+}
+
+#player-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem;
+    border-radius: 0.2rem;
+    transition: background-color 0.2s ease;
+}
+
+#player-list li:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.player-head {
+    width: 30px;
+    height: 30px;
+    image-rendering: pixelated;
+}
+
+.player-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #messages {
@@ -56,12 +114,12 @@ body {
 
 .message {
     position: relative;
-    margin: 0.25rem 0;
-    padding: 0.25rem 0.5rem;
+    margin: 0.22rem 0;
+    padding: 0.22rem 0.5rem;
     word-wrap: break-word;
     display: flex;
     flex-direction: row;
-    align-items: start;
+    align-items: flex-start;  /* Ensure items start from the top */
 }
 
 .message.ping {
@@ -89,7 +147,8 @@ body {
     color: #b7b7b7;
     font-size: 0.75rem;
     margin-right: 0.3rem;
-    margin-top: 0.15rem;
+    padding-top: 0.25rem;
+    flex-shrink: 0;
 }
 
 #input-area {
@@ -133,12 +192,15 @@ body {
 
 #status {
     position: fixed;
-    top: 1rem;
-    right: 1rem;
+    width: 250px;
+    right: 0.5rem;
+    bottom: 0.5rem;
     padding: 0.3rem 0.6rem;
     border-radius: 0.3rem;
     background-color: rgba(0, 0, 0, 0.5);
     font-size: 0.8rem;
+    box-sizing: border-box;
+    text-align: center;
 }
 
 .status-connected {
@@ -151,4 +213,26 @@ body {
 
 .status-error {
     color: #ff9800;
+}
+
+/*
+ Primitive but functional phone support by hiding the player list.
+*/
+@media (max-width: 620px) {
+    #container {
+        padding-top: 2.5rem;  /* Make room for status bar */
+    }
+
+    #player-list-container {
+        display: none;
+    }
+
+    #status {
+        top: 0.5rem;
+        bottom: auto;
+        left: 50%;
+        transform: translateX(-50%);
+        width: calc(100% - 1rem);
+        max-width: 400px;
+    }
 }

--- a/src/client/resources/web/index.html
+++ b/src/client/resources/web/index.html
@@ -12,23 +12,29 @@
     <link rel="stylesheet" href="css/message_formatting.css">
 </head>
 <body>
-<div id="container">
-    <div id="messages">
-        <div id="load-more-container">
-            <button id="load-more-button">Load More</button>
+    <div id="container">
+        <div id="chat-area">
+            <div id="messages">
+                <div id="load-more-container">
+                    <button id="load-more-button">Load More</button>
+                </div>
+            </div>
+            <div id="input-area">
+                <textarea id="message-input" placeholder="Type your message..." rows="1"></textarea>
+                <button id="message-send-button">Send</button>
+            </div>
+        </div>
+        <div id="player-list-container">
+            <h2>Players Online <span id="player-count">(0)</span></h2>
+            <ul id="player-list"></ul>
         </div>
     </div>
-    <div id="input-area">
-        <textarea id="message-input" placeholder="Type your message..." rows="1"></textarea>
-        <button id="message-send-button">Send</button>
+    <div id="status" class="status-disconnected">
+        <span class="connection-status">Disconnected</span>
+        -
+        <span class="server-name">No server</span>
     </div>
-</div>
-<div id="status" class="status-disconnected">
-    <span class="connection-status">Disconnected</span>
-    -
-    <span class="server-name">No server</span>
-</div>
 
-<script type="module" src="js/chat.mjs"></script>
+    <script type="module" src="js/chat.mjs"></script>
 </body>
 </html>

--- a/src/client/resources/web/js/message_types.mjs
+++ b/src/client/resources/web/js/message_types.mjs
@@ -44,6 +44,24 @@
  */
 
 /**
+ * Player information matching PlayerListInfoEntry on server
+ * @typedef {Object} PlayerInfo
+ * @property {string} playerId
+ * @property {string} playerName
+ * @property {string} playerDisplayName
+ * @property {string} playerTextureUrl
+ */
+
+/**
+ * ServerPlayerList message from Minecraft
+ * @typedef {BaseModServerMessage & {
+*   type: 'serverPlayerList',
+*   payload: PlayerInfo[]
+* }} ServerPlayerList
+*/
+
+
+/**
  * @typedef {'init'| 'join' | 'disconnect'} ServerConnectionStates
  */
 
@@ -56,7 +74,7 @@
  */
 
 /**
- * @typedef {BaseModServerMessage & (ChatMessage | ServerConnectionState | HistoryMetaData)} ModServerMessage
+ * @typedef {BaseModServerMessage & (ChatMessage | ServerConnectionState | HistoryMetaData | ServerPlayerList)} ModServerMessage
  */
 
 /**
@@ -75,7 +93,8 @@ export function isModServerMessage(message) {
 
     return message.type === 'chatMessage' ||
         message.type === 'serverConnectionState' ||
-        message.type === 'historyMetaData';
+        message.type === 'historyMetaData' ||
+        message.type === 'serverPlayerList';
 }
 
 /**

--- a/src/client/resources/web/js/util.mjs
+++ b/src/client/resources/web/js/util.mjs
@@ -35,7 +35,7 @@ export function updateFavicon(count, hasPing) {
             // Default image, will restore the favicon.
             img.src = `img/icon_${size}.png`;
         }
-        
+
         img.onload = () => {
             ctx.drawImage(img, 0, 0, size, size);
 
@@ -62,14 +62,14 @@ export function updateFavicon(count, hasPing) {
  */
 export function formatTimestamp(timestamp) {
     const date = new Date(timestamp);
-    
+
     // Format HH:MM for display
-    const timeString = date.toLocaleTimeString([], { 
-        hour: '2-digit', 
+    const timeString = date.toLocaleTimeString([], {
+        hour: '2-digit',
         minute: '2-digit',
-        hour12: false 
+        hour12: false
     });
-    
+
     // Full date and time for tooltip
     const fullDateTime = date.toLocaleString([], {
         year: 'numeric',
@@ -80,6 +80,88 @@ export function formatTimestamp(timestamp) {
         second: '2-digit',
         hour12: false
     });
-    
+
     return { timeString, fullDateTime };
+}
+
+
+/** @type {string} Default Steve head texture as base64 */
+export const STEVE_HEAD_BASE64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAAXNSR0IArs4c6QAAANNJREFUKFNjNFYR/M/AwMDAw8YCouDgy68/DD9+/WFgVJHg+M/PwwmWgCkCSYLYIJpRW473f4GrDYOEmCgDCxcvw59vnxm+//zN8PHjB4aZh04yMM5O9vzPzy/AwMnOCjYFJAkDIEWMq4oi/4f2LmMItutiiDC9ANa5/ZYDw9pDZQyri6MQJoB0HTh3HazZwUgTTINNmBBp//8/63+GXccvMejJqoIlTt++yuDraMLw6etvBsYpCXb/337+zXDw1EUGdg42hp8/foFpCz1NBj5uVgYAzxRTZRWSVwUAAAAASUVORK5CYII='
+
+/** @type {number} Timeout in milliseconds for texture fetching */
+const FETCH_TIMEOUT = 1000;
+
+/**
+ * Fetches a minecraft texture
+ * @param {string} url - The URL to fetch the texture from
+ * @returns {Promise<Blob>} The fetched texture as a Blob
+ */
+async function fetchTexture(url) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+
+    try {
+        const response = await fetch(url, { signal: controller.signal });
+        clearTimeout(timeoutId);
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        return await response.blob();
+    } catch (error) {
+        clearTimeout(timeoutId);
+
+        if (error instanceof Error) {
+            throw error.name === 'AbortError'
+                ? new Error(`Request timed out after ${FETCH_TIMEOUT}ms`)
+                : error;
+        }
+        throw new Error(`Unknown error occurred: ${String(error)}`);
+    }
+}
+
+/**
+ * Extracts the head portion of a Minecraft skin texture
+ * @param {string} textureUrl - The URL of the full skin texture
+ * @returns {Promise<string>} Base64 encoded PNG of the player's head. Or Steve's head if there's an error
+ */
+export async function getPlayerHead(textureUrl) {
+    try {
+        const blob = await fetchTexture(textureUrl);
+        const arrayBuffer = await blob.arrayBuffer();
+        const base64 = btoa(
+            new Uint8Array(arrayBuffer)
+                .reduce((data, byte) => data + String.fromCharCode(byte), '')
+        );
+
+        const img = new Image();
+        img.src = `data:${blob.type};base64,${base64}`;
+
+        await new Promise((resolve, reject) => {
+            img.onload = resolve;
+            img.onerror = () => reject(new Error('Failed to load image'));
+        });
+
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+            throw new Error('Failed to get canvas context');
+        }
+
+        canvas.width = 8;
+        canvas.height = 8;
+
+        // The head is located in the top left corner 8 pixels from both sides.
+        ctx.drawImage(img, 8, 8, 8, 8, 0, 0, 8, 8);
+
+        // Draw the head overlay layer
+        ctx.drawImage(img, 40, 8, 8, 8, 0, 0, 8, 8);
+
+        return canvas.toDataURL('image/png');
+    } catch (error) {
+        console.warn('Error processing player head, using Steve head as fallback:', error);
+        return STEVE_HEAD_BASE64;
+    }
 }


### PR DESCRIPTION
Fixes #5 

![image](https://github.com/user-attachments/assets/0630b057-4e52-4446-94bf-5e886238ffe9)


A few implementation notes: 

- Updates the playerlist on an interval. For some bizarre reason it is trivial to get the complete list as a client but an event to listen for joins and leaves is not available through Fabric. Solutions I came across involved creating mixins, which is effectively reflection and very prone to breaking on new minecraft versions. Because of that I decided to go for the interval route as it effectively is just some lookups. 
- Player skins are handled by the client by fetching them from minecraft.net. In theory it is possible to fetch the textures from the client and send those along. But in practice I had little luck with that due to asynchronous loading of textures and various other factures. It likely would also make the whole operation a bit heavier which in combination with the interval for updates might actually cause some issues. The texture URL is trivial to fetch, so that is send along to the client and the client handles the head creation. 
