### PR TITLE
#67 Support for legacy color/format codes and multi-space formatting

### DIFF
--- a/src/client/resources/web/js/chat.mjs
+++ b/src/client/resources/web/js/chat.mjs
@@ -5,7 +5,7 @@ import { querySelectorWithAssertion, formatTimestamp } from './utils.mjs';
 import {
     assertIsComponent,
     ComponentError,
-    formatComponent,
+    formatChatMessage,
     initializeObfuscation,
 } from './messages/message_parsing.mjs';
 import { serverInfo } from './managers/server_info.mjs';
@@ -185,14 +185,14 @@ function handleChatMessage(message) {
         try {
             // Format the chat message - this uses the Component format from message_parsing
             assertIsComponent(message.payload.component);
-            const chatContent = formatComponent(message.payload.component);
+            const chatContent = formatChatMessage(message.payload.component);
             messageElement.appendChild(chatContent);
         } catch (e) {
             console.error(message);
             if (e instanceof ComponentError) {
                 console.error('Invalid component:', e.toString());
                 messageElement.appendChild(
-                    formatComponent({
+                    formatChatMessage({
                         text: 'Invalid message received from server',
                         color: 'red',
                     }),
@@ -200,7 +200,7 @@ function handleChatMessage(message) {
             } else {
                 console.error('Error parsing message:', e);
                 messageElement.appendChild(
-                    formatComponent({
+                    formatChatMessage({
                         text: 'Error parsing message',
                         color: 'red',
                     }),

--- a/src/test/resources/web/js/message_parsing.test.mjs
+++ b/src/test/resources/web/js/message_parsing.test.mjs
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import {
     assertIsComponent,
-    formatComponent,
+    formatChatMessage,
 } from '~/messages/message_parsing.mjs';
 /**
  * @typedef {import('~/messages/message_parsing.mjs').Component} Component
@@ -618,13 +618,63 @@ const COMPONENT_FORMATTING_TESTS = [
             '</span>' +
             '</span>',
     ],
+
+    // Legacy color codes
+    [
+        'legacy color code',
+        { text: '§4test' },
+        '<span><span class="mc-dark-red">test</span></span>',
+    ],
+    [
+        'legacy color code with bold',
+        { text: '§4§ltest' },
+        '<span><span class="mc-bold mc-dark-red">test</span></span>',
+    ],
+    ['legacy color code with reset', { text: '§4§rtest' }, '<span>test</span>'],
+    [
+        'all color codes',
+        { text: '§0§1§2§3§4§5§6§7§8§9§a§b§c§d§e§ftest' },
+        '<span><span class="mc-white">test</span></span>',
+    ],
+    ['invalid color code', { text: '§xtest' }, '<span>§xtest</span>'],
+    [
+        'legacy color code with bold and reset',
+        { text: '§4§ltest§rtest' },
+        '<span><span class="mc-bold mc-dark-red">test</span>test</span>',
+    ],
+    [
+        'complex nested formatting',
+        { text: '§4§l[§r§6Warning§4§l]§r: §7Message' },
+        '<span>' +
+            '<span class="mc-bold mc-dark-red">[</span>' +
+            '<span class="mc-gold">Warning</span>' +
+            '<span class="mc-bold mc-dark-red">]</span>' +
+            ': <span class="mc-gray">Message</span>' +
+            '</span>',
+    ],
+    [
+        'formatting codes within a translation',
+        {
+            translate: 'argument.item.id.invalid',
+            color: 'red',
+            with: [{ text: '§4§ltest§r', color: 'blue' }],
+        },
+        '<span class="mc-red">Unknown item \'<span class="mc-blue"><span class="mc-bold mc-dark-red">test</span></span>\'</span>',
+    ],
+
+    // Non-breaking spaces
+    [
+        'multiple spaces',
+        { text: 'test   test' },
+        '<span>test&nbsp;&nbsp;&nbsp;test</span>',
+    ],
 ];
 
 for (const [name, component, expected] of COMPONENT_FORMATTING_TESTS) {
     test(name, () => {
         expect(() => assertIsComponent(component)).not.toThrow();
 
-        const element = formatComponent(component);
+        const element = formatChatMessage(component);
         if (element instanceof Text) {
             expect(element.textContent).toBe(expected);
         } else {


### PR DESCRIPTION
Fixes: #67 

Adds support for:

* Setting colors with `§[0-9a-f]`
* Formatting with `§[rklmno]`
* Non-breaking space formatting, used by some plugins (would work better if we used a monospaced font like the game does)