### PR TITLE
#76 Add support for loading static web files from outside the .jar

### DIFF
--- a/src/client/java/dev/creesch/WebchatClient.java
+++ b/src/client/java/dev/creesch/WebchatClient.java
@@ -154,17 +154,22 @@ public class WebchatClient implements ClientModInitializer {
         if (INSTANCE.webInterface == null) {
             return;
         }
-        if (
-            INSTANCE.webInterface.getCurrentPort() ==
-            ModConfig.HANDLER.instance().httpPortNumber
-        ) {
-            return;
-        }
 
-        // Port has changed, shutdown the old instance and create a new one.
-        INSTANCE.webInterface.shutdown();
-        INSTANCE.webInterface = new WebInterface(INSTANCE.messageRepository);
-        INSTANCE.showWebAddress(MinecraftClient.getInstance());
+        boolean portChanged =
+            INSTANCE.webInterface.getCurrentPort() !=
+            ModConfig.HANDLER.instance().httpPortNumber;
+
+        boolean pathChanged =
+            INSTANCE.webInterface.getCurrentPath() !=
+            ModConfig.HANDLER.instance().staticFilesPath;
+
+        if (portChanged || pathChanged) {
+            INSTANCE.webInterface.shutdown();
+            INSTANCE.webInterface = new WebInterface(
+                INSTANCE.messageRepository
+            );
+            INSTANCE.showWebAddress(MinecraftClient.getInstance());
+        }
     }
 
     private void showWebAddress(MinecraftClient client) {

--- a/src/client/java/dev/creesch/config/ModConfig.java
+++ b/src/client/java/dev/creesch/config/ModConfig.java
@@ -36,6 +36,12 @@ public class ModConfig {
     @SerialEntry(comment = "Extra ping keywords")
     public List<String> pingKeywords = Arrays.asList();
 
+    @SerialEntry(comment = "Enable development mode")
+    public boolean developmentMode = false;
+
+    @SerialEntry(comment = "Web interface static files path")
+    public String staticFilesPath = "";
+
     public static void init() {
         HANDLER.load();
     }

--- a/src/client/java/dev/creesch/config/ModConfigScreen.java
+++ b/src/client/java/dev/creesch/config/ModConfigScreen.java
@@ -10,117 +10,149 @@ import net.minecraft.text.Text;
 public class ModConfigScreen {
 
     public static Screen createScreen(Screen parent) {
-        return YetAnotherConfigLib.createBuilder()
-            .title(Text.literal("Web Chat Configuration"))
-            .category(
-                ConfigCategory.createBuilder()
-                    .name(Text.literal("Message Settings"))
-                    .group(
-                        OptionGroup.createBuilder()
-                            .name(Text.literal("Ping Settings"))
-                            .option(
-                                Option.<Boolean>createBuilder()
-                                    .name(Text.literal("Ping on Username"))
-                                    .description(
-                                        OptionDescription.of(
-                                            Text.literal(
-                                                "Enable ping on username.\n" +
-                                                "This will ping the browser window any time a player's username appears in the chat " +
-                                                "(case insensitive)."
-                                            )
+        YetAnotherConfigLib.Builder builder =
+            YetAnotherConfigLib.createBuilder()
+                .title(Text.literal("Web Chat Configuration"));
+
+        builder.category(
+            ConfigCategory.createBuilder()
+                .name(Text.literal("Message Settings"))
+                .group(
+                    OptionGroup.createBuilder()
+                        .name(Text.literal("Ping Settings"))
+                        .option(
+                            Option.<Boolean>createBuilder()
+                                .name(Text.literal("Ping on Username"))
+                                .description(
+                                    OptionDescription.of(
+                                        Text.literal(
+                                            "Enable ping on username.\n" +
+                                            "This will ping the browser window any time a player's username appears in the chat " +
+                                            "(case insensitive)."
                                         )
-                                    )
-                                    .binding(
-                                        ModConfig.HANDLER.defaults()
-                                            .pingOnUsername,
-                                        () ->
-                                            ModConfig.HANDLER.instance()
-                                                .pingOnUsername,
-                                        val ->
-                                            ModConfig.HANDLER.instance()
-                                                .pingOnUsername = val
-                                    )
-                                    .controller(
-                                        BooleanControllerBuilder::create
-                                    )
-                                    .build()
-                            )
-                            .build()
-                    )
-                    .group(
-                        ListOption.<String>createBuilder()
-                            .name(Text.literal("Extra Ping Keywords"))
-                            .description(
-                                OptionDescription.of(
-                                    Text.literal(
-                                        "Extra keywords to ping on.\n" +
-                                        "This will ping the browser window any time one of these words appear in the chat " +
-                                        "(case insensitive)."
                                     )
                                 )
+                                .binding(
+                                    ModConfig.HANDLER.defaults().pingOnUsername,
+                                    () ->
+                                        ModConfig.HANDLER.instance()
+                                            .pingOnUsername,
+                                    val ->
+                                        ModConfig.HANDLER.instance()
+                                            .pingOnUsername = val
+                                )
+                                .controller(BooleanControllerBuilder::create)
+                                .build()
+                        )
+                        .build()
+                )
+                .group(
+                    ListOption.<String>createBuilder()
+                        .name(Text.literal("Extra Ping Keywords"))
+                        .description(
+                            OptionDescription.of(
+                                Text.literal(
+                                    "Extra keywords to ping on.\n" +
+                                    "This will ping the browser window any time one of these words appear in the chat " +
+                                    "(case insensitive)."
+                                )
                             )
-                            .binding(
-                                ModConfig.HANDLER.defaults().pingKeywords,
-                                () -> ModConfig.HANDLER.instance().pingKeywords,
-                                val ->
-                                    ModConfig.HANDLER.instance().pingKeywords =
-                                        val
-                            )
-                            .controller(StringControllerBuilder::create)
-                            .initial("")
-                            .build()
-                    )
-                    .build()
-            )
-            .category(
+                        )
+                        .binding(
+                            ModConfig.HANDLER.defaults().pingKeywords,
+                            () -> ModConfig.HANDLER.instance().pingKeywords,
+                            val ->
+                                ModConfig.HANDLER.instance().pingKeywords = val
+                        )
+                        .controller(StringControllerBuilder::create)
+                        .initial("")
+                        .build()
+                )
+                .build()
+        );
+
+        builder.category(
+            ConfigCategory.createBuilder()
+                .name(Text.literal("Network Settings"))
+                .group(
+                    OptionGroup.createBuilder()
+                        .name(Text.literal("Port Settings"))
+                        .option(
+                            Option.<Integer>createBuilder()
+                                .name(Text.literal("HTTP Port"))
+                                .description(
+                                    OptionDescription.of(
+                                        Text.literal(
+                                            "Port number used to serve the web interface.\n" +
+                                            "Make sure that this port is available."
+                                        )
+                                    )
+                                )
+                                .binding(
+                                    ModConfig.HANDLER.defaults().httpPortNumber,
+                                    () ->
+                                        ModConfig.HANDLER.instance()
+                                            .httpPortNumber,
+                                    val ->
+                                        ModConfig.HANDLER.instance()
+                                            .httpPortNumber = val
+                                )
+                                .controller(opt ->
+                                    IntegerFieldControllerBuilder.create(opt)
+                                        .range(1024, 65535)
+                                        .formatValue(value ->
+                                            Text.literal(String.valueOf(value))
+                                        )
+                                )
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        if (ModConfig.HANDLER.instance().developmentMode) {
+            builder.category(
                 ConfigCategory.createBuilder()
-                    .name(Text.literal("Network Settings"))
+                    .name(Text.literal("Development Settings"))
                     .group(
                         OptionGroup.createBuilder()
-                            .name(Text.literal("Port Settings"))
+                            .name(Text.literal("Static Files Path"))
                             .option(
-                                Option.<Integer>createBuilder()
-                                    .name(Text.literal("HTTP Port"))
+                                Option.<String>createBuilder()
+                                    .name(Text.literal("Path"))
                                     .description(
                                         OptionDescription.of(
                                             Text.literal(
-                                                "Port number used to serve the web interface.\n" +
-                                                "Make sure that this port is available."
+                                                "Path to the static files for the web interface.\n" +
+                                                "Leave blank to use files included in the mod jar."
                                             )
                                         )
                                     )
                                     .binding(
                                         ModConfig.HANDLER.defaults()
-                                            .httpPortNumber,
+                                            .staticFilesPath,
                                         () ->
                                             ModConfig.HANDLER.instance()
-                                                .httpPortNumber,
+                                                .staticFilesPath,
                                         val ->
                                             ModConfig.HANDLER.instance()
-                                                .httpPortNumber = val
+                                                .staticFilesPath = val
                                     )
-                                    .controller(opt ->
-                                        IntegerFieldControllerBuilder.create(
-                                            opt
-                                        )
-                                            .range(1024, 65535)
-                                            .formatValue(value ->
-                                                Text.literal(
-                                                    String.valueOf(value)
-                                                )
-                                            )
-                                    )
+                                    .controller(StringControllerBuilder::create)
                                     .build()
                             )
                             .build()
                     )
                     .build()
-            )
-            .save(() -> {
-                ModConfig.HANDLER.save();
-                dev.creesch.WebchatClient.onConfigChanged();
-            })
-            .build()
-            .generateScreen(parent);
+            );
+        }
+
+        builder.save(() -> {
+            ModConfig.HANDLER.save();
+            dev.creesch.WebchatClient.onConfigChanged();
+        });
+
+        return builder.build().generateScreen(parent);
     }
 }


### PR DESCRIPTION
Not quite hot reloading, but this is certainly an improvement.

I realized using a separate file server to hot reload wouldn't be ideal as we would be missing out on the configuration made to Javalin (like the `Content-Security-Policy` header).

This PR adds two new configuration options:

* `developmentMode` - Must be enabled or disabled by editing the mod's .json5 file. All this does is enable the "Development Settings" panel in the mod setting UI.
* `staticFilesPath` - Defaults to `""`. When set will use the string as an absolute path for the root of the static files. Reloads the Javalin server when this value changes.