### PR TITLE
Handle legacy text formatting in server names

### DIFF
--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -145,6 +145,7 @@ body {
     margin: 0.22rem 0;
     padding: 0.22rem 0.5rem;
     word-wrap: break-word;
+    white-space: pre-wrap;
     display: flex;
     flex-direction: row;
     align-items: flex-start; /* Ensure items start from the top */

--- a/src/client/resources/web/js/managers/server_info.mjs
+++ b/src/client/resources/web/js/managers/server_info.mjs
@@ -55,7 +55,7 @@ class ServerInfo {
         )}`;
         this.#serverNameElement.textContent = name;
 
-        formatPlainText(this.#serverNameElement, false);
+        formatPlainText(this.#serverNameElement);
     }
 
     /**

--- a/src/client/resources/web/js/managers/server_info.mjs
+++ b/src/client/resources/web/js/managers/server_info.mjs
@@ -2,6 +2,7 @@
 'use strict';
 
 import { querySelectorWithAssertion } from '../utils.mjs';
+import { formatPlainText } from '../messages/message_parsing.mjs';
 
 /**
  * Class to manage server information and related UI updates
@@ -47,6 +48,8 @@ class ServerInfo {
 
         document.title = `${this.#baseTitle} - ${name}`;
         this.#serverNameElement.textContent = name;
+
+        formatPlainText(this.#serverNameElement, false);
     }
 
     /**

--- a/src/client/resources/web/js/managers/server_info.mjs
+++ b/src/client/resources/web/js/managers/server_info.mjs
@@ -46,7 +46,7 @@ class ServerInfo {
         this.#name = name;
         this.#id = id;
 
-        document.title = `${this.#baseTitle} - ${name}`;
+        document.title = `${this.#baseTitle} - ${name.replace(/§[0-9a-frklmno]/g, '')}`;
         this.#serverNameElement.textContent = name;
 
         formatPlainText(this.#serverNameElement, false);

--- a/src/client/resources/web/js/managers/server_info.mjs
+++ b/src/client/resources/web/js/managers/server_info.mjs
@@ -2,7 +2,10 @@
 'use strict';
 
 import { querySelectorWithAssertion } from '../utils.mjs';
-import { formatPlainText } from '../messages/message_parsing.mjs';
+import {
+    formatPlainText,
+    TEXT_CODES_PATTERN,
+} from '../messages/message_parsing.mjs';
 
 /**
  * Class to manage server information and related UI updates
@@ -46,7 +49,10 @@ class ServerInfo {
         this.#name = name;
         this.#id = id;
 
-        document.title = `${this.#baseTitle} - ${name.replace(/§[0-9a-frklmno]/g, '')}`;
+        document.title = `${this.#baseTitle} - ${name.replace(
+            new RegExp(TEXT_CODES_PATTERN, 'g'),
+            '',
+        )}`;
         this.#serverNameElement.textContent = name;
 
         formatPlainText(this.#serverNameElement, false);

--- a/src/client/resources/web/js/messages/message_parsing.mjs
+++ b/src/client/resources/web/js/messages/message_parsing.mjs
@@ -43,6 +43,7 @@ const FORMATTING_CODES = {
 
 /** @type {Record<string, string>} */
 const TEXT_CODES = { ...COLOR_CODES, ...FORMATTING_CODES };
+export const TEXT_CODES_PATTERN = `§([${Object.keys(TEXT_CODES).join('')}])`;
 
 const VALID_HOVER_EVENTS = ['show_text', 'show_item', 'show_entity'];
 
@@ -647,7 +648,7 @@ function createFormattedElement(text, codes) {
  */
 function colorizeText(text) {
     const result = [];
-    const regex = new RegExp(`§([${Object.keys(TEXT_CODES).join('')}])`, 'g');
+    const regex = new RegExp(TEXT_CODES_PATTERN, 'g');
     let lastIndex = 0;
     let match = regex.exec(text);
 

--- a/src/client/resources/web/js/messages/message_parsing.mjs
+++ b/src/client/resources/web/js/messages/message_parsing.mjs
@@ -1029,14 +1029,11 @@ function formatComponent(component) {
     return result;
 }
 
-const NON_BREAKING_SPACE = '\u00A0';
-
 /**
  * Transforms text content into HTML using § codes.
  * @param {Element} element
- * @param {boolean} preserveSpacing
  */
-export function formatPlainText(element, preserveSpacing) {
+export function formatPlainText(element) {
     const walker = document.createTreeWalker(
         element,
         NodeFilter.SHOW_TEXT,
@@ -1050,19 +1047,10 @@ export function formatPlainText(element, preserveSpacing) {
     }
 
     for (const textNode of textNodes) {
-        let text = textNode.textContent ?? '';
-
-        if (preserveSpacing) {
-            // Replace runs of 2+ spaces with non-breaking spaces
-            text = text.replace(/[ ]{2,}/g, (match) =>
-                NON_BREAKING_SPACE.repeat(match.length),
-            );
-        }
-
         const parent = textNode.parentNode;
         if (!parent) continue;
 
-        const linkedElements = linkifyText(text);
+        const linkedElements = linkifyText(textNode.textContent ?? '');
 
         const finalElements = linkedElements.flatMap((element) => {
             if (element instanceof HTMLAnchorElement) {
@@ -1100,7 +1088,7 @@ export function formatChatMessage(component) {
     }
 
     // Second pass: transform the text content of the element and its children
-    formatPlainText(element, true);
+    formatPlainText(element);
 
     return element;
 }

--- a/src/client/resources/web/js/messages/message_parsing.mjs
+++ b/src/client/resources/web/js/messages/message_parsing.mjs
@@ -1031,10 +1031,11 @@ function formatComponent(component) {
 const NON_BREAKING_SPACE = '\u00A0';
 
 /**
- * Transforms text content into HTML.
+ * Transforms text content into HTML using § codes.
  * @param {Element} element
+ * @param {boolean} preserveSpacing
  */
-function formatPlainText(element) {
+export function formatPlainText(element, preserveSpacing) {
     const walker = document.createTreeWalker(
         element,
         NodeFilter.SHOW_TEXT,
@@ -1050,10 +1051,12 @@ function formatPlainText(element) {
     for (const textNode of textNodes) {
         let text = textNode.textContent ?? '';
 
-        // Replace runs of 2+ spaces with non-breaking spaces
-        text = text.replace(/[ ]{2,}/g, (match) =>
-            NON_BREAKING_SPACE.repeat(match.length),
-        );
+        if (preserveSpacing) {
+            // Replace runs of 2+ spaces with non-breaking spaces
+            text = text.replace(/[ ]{2,}/g, (match) =>
+                NON_BREAKING_SPACE.repeat(match.length),
+            );
+        }
 
         const parent = textNode.parentNode;
         if (!parent) continue;
@@ -1096,7 +1099,7 @@ export function formatChatMessage(component) {
     }
 
     // Second pass: transform the text content of the element and its children
-    formatPlainText(element);
+    formatPlainText(element, true);
 
     return element;
 }

--- a/src/test/resources/web/js/message_parsing.test.mjs
+++ b/src/test/resources/web/js/message_parsing.test.mjs
@@ -661,13 +661,6 @@ const COMPONENT_FORMATTING_TESTS = [
         },
         '<span class="mc-red">Unknown item \'<span class="mc-blue"><span class="mc-bold mc-dark-red">test</span></span>\'</span>',
     ],
-
-    // Non-breaking spaces
-    [
-        'multiple spaces',
-        { text: 'test   test' },
-        '<span>test&nbsp;&nbsp;&nbsp;test</span>',
-    ],
 ];
 
 for (const [name, component, expected] of COMPONENT_FORMATTING_TESTS) {


### PR DESCRIPTION
The fancy servers use text formatting codes in their server names

<img width="961" alt="Screenshot 2025-02-09 at 10 09 39 PM" src="https://github.com/user-attachments/assets/93937e0b-06d7-40fa-a930-33c3ce50efb4" />
