### PR TITLE
#81 Add support for direct-message commands

### DIFF
--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -42,6 +42,9 @@ public class WebInterface {
         "[\\n\\r§\u00A7\\u0000-\\u001F\\u200B-\\u200F\\u2028-\\u202F]"
     );
     private static final Pattern MULTIPLE_SPACES = Pattern.compile("\\s{2,}");
+    private static final Pattern SUPPORTED_COMMANDS = Pattern.compile(
+        "^/(msg|tell|w|me)(\\s|$)"
+    );
 
     private String staticFilesPath = "";
     private final AtomicBoolean shutdownInitiated = new AtomicBoolean(false);
@@ -352,12 +355,7 @@ public class WebInterface {
             }
 
             int maxLength = 256;
-            if (
-                message.startsWith("/msg ") ||
-                message.startsWith("/tell ") ||
-                message.startsWith("/w ") ||
-                message.startsWith("/me ")
-            ) {
+            if (SUPPORTED_COMMANDS.matcher(message).matches()) {
                 String slash = "/";
                 int end = Math.min(
                     message.length(),

--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -355,7 +355,8 @@ public class WebInterface {
             if (
                 message.startsWith("/msg ") ||
                 message.startsWith("/tell ") ||
-                message.startsWith("/w ")
+                message.startsWith("/w ") ||
+                message.startsWith("/me ")
             ) {
                 String slash = "/";
                 int end = Math.min(

--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -352,6 +352,23 @@ public class WebInterface {
             }
 
             int maxLength = 256;
+            if (
+                message.startsWith("/msg ") ||
+                message.startsWith("/tell ") ||
+                message.startsWith("/w ")
+            ) {
+                String slash = "/";
+                int end = Math.min(
+                    message.length(),
+                    maxLength + slash.length()
+                );
+                // Remove the leading slash and truncate to maxLength.
+                player.networkHandler.sendChatCommand(
+                    message.substring(slash.length(), end)
+                );
+                return;
+            }
+
             if (message.length() <= maxLength) {
                 player.networkHandler.sendChatMessage(message);
                 return;

--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -43,7 +43,8 @@ public class WebInterface {
     );
     private static final Pattern MULTIPLE_SPACES = Pattern.compile("\\s{2,}");
     private static final Pattern SUPPORTED_COMMANDS = Pattern.compile(
-        "^/(msg|tell|w|me)(\\s|$)"
+        "^/(msg|tell|w|me)(\\s.*|$)",
+        Pattern.CASE_INSENSITIVE
     );
 
     private String staticFilesPath = "";

--- a/src/client/resources/web/js/managers/tab_list_manager.mjs
+++ b/src/client/resources/web/js/managers/tab_list_manager.mjs
@@ -245,11 +245,15 @@ class TabListManager {
         const beforeCursor = value.substring(0, cursorPos);
         const afterCursor = value.substring(cursorPos);
 
+        // Use playerName instead of playerDisplayName for direct-message commands
+        const playerNameToInsert = beforeCursor.match(/^\/(tell|msg|w)[ ]+$/)
+            ? selectedPlayer.playerName
+            : selectedPlayer.playerDisplayName;
+
         // There is a partial player name before the cursor. Get everything
         // before it and add the full player name after.
         const prefix = beforeCursor.match(/(.*?)\b\w+$/);
-        const newBeforeCursor =
-            (prefix?.[1] ?? '') + selectedPlayer.playerDisplayName;
+        const newBeforeCursor = (prefix?.[1] ?? '') + playerNameToInsert;
         chatInputElement.value = newBeforeCursor + afterCursor;
 
         // Update the cursor position.


### PR DESCRIPTION
Fixes: #81 

Supports `/tell`, `/msg`, and `/w` which all appear to be vanilla.

**Edit**: I also added `/me` as it's just a fancy chat message.