### PR TITLE
Store translations with messages on receiving them. Fixes #23

### DIFF
--- a/src/client/java/dev/creesch/model/ChatMessagePayload.java
+++ b/src/client/java/dev/creesch/model/ChatMessagePayload.java
@@ -1,6 +1,7 @@
 package dev.creesch.model;
 
 import com.google.gson.JsonObject;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,5 +12,6 @@ public class ChatMessagePayload {
     private boolean history;
     private String uuid;
     private JsonObject component;
+    private Map<String, String> translations;
     private boolean isPing;
 }

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -3,11 +3,15 @@ package dev.creesch.model;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import dev.creesch.config.ModConfig;
+import dev.creesch.util.ClientTranslationUtils;
 import dev.creesch.util.MinecraftServerIdentifier;
 import dev.creesch.util.NamedLogger;
+
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
@@ -15,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
@@ -45,6 +50,9 @@ public class WebsocketMessageBuilder {
             );
         }
 
+        Map<String, String> translations =
+            ClientTranslationUtils.extractTranslations(message);
+
         // Can't use GSON for Text serialization easily, using Minecraft's own serializer.
         String minecraftChatJson = Text.Serialization.toJsonString(
             message,
@@ -67,6 +75,7 @@ public class WebsocketMessageBuilder {
             .uuid(messageUUID)
             .component(gson.fromJson(minecraftChatJson, JsonObject.class))
             .isPing(!fromSelf && isPing(message, client))
+            .translations(translations)
             .build();
 
         return WebsocketJsonMessage.createChatMessage(
@@ -148,14 +157,19 @@ public class WebsocketMessageBuilder {
         String serverName,
         String messageId,
         String messageJson,
+        String translationsJson,
         boolean isPing,
         String minecraftVersion
     ) {
         // Back to objects we go
+        LOGGER.info(translationsJson);
+        Type type = new TypeToken<Map<String, String>>(){}.getType();
+        Map<String, String> translations = gson.fromJson(translationsJson, type);
         ChatMessagePayload messageObject = ChatMessagePayload.builder()
             .history(true)
             .uuid(messageId)
             .component(gson.fromJson(messageJson, JsonObject.class))
+            .translations(translations)
             .isPing(isPing)
             .build();
 

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -10,7 +10,6 @@ import dev.creesch.config.ModConfig;
 import dev.creesch.util.ClientTranslationUtils;
 import dev.creesch.util.MinecraftServerIdentifier;
 import dev.creesch.util.NamedLogger;
-
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -163,8 +162,11 @@ public class WebsocketMessageBuilder {
     ) {
         // Back to objects we go
         LOGGER.info(translationsJson);
-        Type type = new TypeToken<Map<String, String>>(){}.getType();
-        Map<String, String> translations = gson.fromJson(translationsJson, type);
+        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        Map<String, String> translations = gson.fromJson(
+            translationsJson,
+            type
+        );
         ChatMessagePayload messageObject = ChatMessagePayload.builder()
             .history(true)
             .uuid(messageId)

--- a/src/client/java/dev/creesch/storage/ChatMessageRepository.java
+++ b/src/client/java/dev/creesch/storage/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package dev.creesch.storage;
 
 import static dev.creesch.model.WebsocketMessageBuilder.createHistoricChatMessage;
 
+import com.google.gson.Gson;
 import dev.creesch.model.ChatMessagePayload;
 import dev.creesch.model.WebsocketJsonMessage;
 import dev.creesch.util.NamedLogger;
@@ -18,11 +19,12 @@ public class ChatMessageRepository {
 
     private static final NamedLogger LOGGER = new NamedLogger("web-chat");
     private final SQLiteDataSource dataSource;
+    private static final Gson gson = new Gson();
 
     // DB constants
     private static final String DB_NAME = "chat_messages.db";
     private static final String DATA_DIR = "web-chat";
-    private static final int CURRENT_SCHEMA_VERSION = 1;
+    private static final int CURRENT_SCHEMA_VERSION = 2;
 
     // SQL queries
     private static final String CREATE_MESSAGES_TABLE_QUERY =
@@ -34,6 +36,7 @@ public class ChatMessageRepository {
             server_name TEXT NOT NULL,
             message_id TEXT NOT NULL,
             message_json TEXT NOT NULL,
+            translations_json TEXT NOT NULL,
             is_ping BOOLEAN NOT NULL,
             minecraft_version TEXT
         )
@@ -69,9 +72,10 @@ public class ChatMessageRepository {
             server_name,
             message_id,
             message_json,
+            translations_json,
             is_ping,
             minecraft_version
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """;
 
     // Base query, needs formatting
@@ -83,6 +87,7 @@ public class ChatMessageRepository {
             server_name,
             message_id,
             message_json,
+            translations_json,
             is_ping,
             minecraft_version
         FROM
@@ -94,6 +99,13 @@ public class ChatMessageRepository {
             timestamp DESC
         LIMIT
             ?
+        """;
+
+    private static final String V2_MIGRATION_QUERY =
+        """
+        ALTER TABLE messages ADD COLUMN translations_json TEXT NOT NULL DEFAULT '{}';
+
+        UPDATE schema_version SET version = 2;
         """;
 
     public ChatMessageRepository() {
@@ -137,6 +149,23 @@ public class ChatMessageRepository {
         }
     }
 
+    // To be used for future migrations as well. Does a rollback if the migration fails.
+    private void executeMigrationQuery(Connection conn, String migrationQuery) throws SQLException {
+        LOGGER.info("Executing migration query {}", migrationQuery);
+        conn.setAutoCommit(false);
+        try {
+            conn.createStatement().executeUpdate(migrationQuery);
+            conn.commit();
+            LOGGER.info("Migration completed successfully");
+        } catch (SQLException e) {
+            conn.rollback();
+            LOGGER.error("Migration failed", e);
+            throw e;
+        } finally {
+            conn.setAutoCommit(true);
+        }
+    }
+
     private void checkSchemaVersion(Connection conn) throws SQLException {
         try (
             Statement stmt = conn.createStatement();
@@ -172,22 +201,12 @@ public class ChatMessageRepository {
                 );
             }
 
-            // Unless someone is messing with the database manually this should not happen yet.
-            // If they are messing with the database it likely isn't good. Throw an error.
-            // TODO: put in actual migration in the future when needed.
-            if (dbVersion < CURRENT_SCHEMA_VERSION) {
-                LOGGER.error(
-                    "Database schema version {} is older than supported version {}. Time travel?",
-                    dbVersion,
-                    CURRENT_SCHEMA_VERSION
-                );
-                throw new RuntimeException(
-                    "Database schema version " +
-                    dbVersion +
-                    " is older than supported version " +
-                    CURRENT_SCHEMA_VERSION
-                );
+            // Version 2 migration
+            if (dbVersion < 2) {
+                LOGGER.info("Migrating database to version 2");
+                executeMigrationQuery(conn, V2_MIGRATION_QUERY);
             }
+
         }
     }
 
@@ -213,8 +232,9 @@ public class ChatMessageRepository {
             statement.setString(3, message.getServer().getName());
             statement.setString(4, payload.getUuid());
             statement.setString(5, payload.getComponent().toString());
-            statement.setBoolean(6, payload.isPing());
-            statement.setString(7, message.getMinecraftVersion());
+            statement.setString(6, gson.toJson(payload.getTranslations()));
+            statement.setBoolean(7, payload.isPing());
+            statement.setString(8, message.getMinecraftVersion());
 
             statement.executeUpdate();
         } catch (SQLException e) {
@@ -256,6 +276,7 @@ public class ChatMessageRepository {
                     String serverName = rs.getString("server_name");
                     String messageId = rs.getString("message_id");
                     String messageJson = rs.getString("message_json");
+                    String translationsJson = rs.getString("translations_json");
                     boolean isPing = rs.getBoolean("is_ping");
                     String minecraftVersion = rs.getString("minecraft_version");
 
@@ -266,6 +287,7 @@ public class ChatMessageRepository {
                             serverName,
                             messageId,
                             messageJson,
+                            translationsJson,
                             isPing,
                             minecraftVersion
                         )

--- a/src/client/java/dev/creesch/storage/ChatMessageRepository.java
+++ b/src/client/java/dev/creesch/storage/ChatMessageRepository.java
@@ -150,7 +150,8 @@ public class ChatMessageRepository {
     }
 
     // To be used for future migrations as well. Does a rollback if the migration fails.
-    private void executeMigrationQuery(Connection conn, String migrationQuery) throws SQLException {
+    private void executeMigrationQuery(Connection conn, String migrationQuery)
+        throws SQLException {
         LOGGER.info("Executing migration query {}", migrationQuery);
         conn.setAutoCommit(false);
         try {
@@ -206,7 +207,6 @@ public class ChatMessageRepository {
                 LOGGER.info("Migrating database to version 2");
                 executeMigrationQuery(conn, V2_MIGRATION_QUERY);
             }
-
         }
     }
 

--- a/src/client/java/dev/creesch/util/ClientTranslationUtils.java
+++ b/src/client/java/dev/creesch/util/ClientTranslationUtils.java
@@ -40,7 +40,7 @@ public class ClientTranslationUtils {
                 if (arg instanceof Text nestedText) {
                     collectTranslationKeys(nestedText, keys); // Recursively handle nested Text
                 } else if (arg instanceof String stringArg) {
-                    keys.putIfAbsent(stringArg, null); // Treat plain strings as potential keys
+                    keys.putIfAbsent(stringArg, null); // Treat plain strings as potential keys. Highly unlikely to ever happen, maybe impossible? Doesn't hurt to account for it.
                 }
             }
         }

--- a/src/client/java/dev/creesch/util/ClientTranslationUtils.java
+++ b/src/client/java/dev/creesch/util/ClientTranslationUtils.java
@@ -2,6 +2,8 @@ package dev.creesch.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import net.minecraft.text.HoverEvent;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Language;
@@ -48,6 +50,32 @@ public class ClientTranslationUtils {
         // Collect keys from siblings (e.g., appended text)
         for (Text sibling : text.getSiblings()) {
             collectTranslationKeys(sibling, keys);
+        }
+
+        // Check hover event for additional text that may contain translation keys
+        HoverEvent hoverEvent = text.getStyle().getHoverEvent();
+        if (hoverEvent == null) {
+            return;
+        }
+
+        // Handle different hover event types
+        if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT) {
+            Text hoverText = hoverEvent.getValue(HoverEvent.Action.SHOW_TEXT);
+            if (hoverText != null) {
+                collectTranslationKeys(hoverText, keys);
+            }
+        }
+
+        if (hoverEvent.getAction() == HoverEvent.Action.SHOW_ENTITY) {
+            // Check if there's a translatable name for the entity
+            HoverEvent.EntityContent hoverEventEntityContent =
+                hoverEvent.getValue(HoverEvent.Action.SHOW_ENTITY);
+            if (hoverEventEntityContent != null) {
+                Optional<Text> entityName = hoverEventEntityContent.name;
+                entityName.ifPresent(value ->
+                    collectTranslationKeys(value, keys)
+                );
+            }
         }
     }
 

--- a/src/client/java/dev/creesch/util/ClientTranslationUtils.java
+++ b/src/client/java/dev/creesch/util/ClientTranslationUtils.java
@@ -1,0 +1,61 @@
+package dev.creesch.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableTextContent;
+import net.minecraft.util.Language;
+
+public class ClientTranslationUtils {
+
+    /**
+     * Extracts all translation keys from a Text object and returns a map of key-value pairs with their translations.
+     * Works in a client-side environment.
+     *
+     * @param text The Text object to process.
+     * @return A map where keys are translation keys and values are the corresponding translations.
+     */
+    public static Map<String, String> extractTranslations(Text text) {
+        Map<String, String> translations = new HashMap<>();
+        collectTranslationKeys(text, translations);
+
+        // Fetch translations for the collected keys
+        populateTranslations(translations);
+
+        return translations;
+    }
+
+    private static void collectTranslationKeys(
+        Text text,
+        Map<String, String> keys
+    ) {
+        if (
+            text.getContent() instanceof
+            TranslatableTextContent translatableContent
+        ) {
+            String key = translatableContent.getKey();
+            keys.putIfAbsent(key, null);
+
+            // Process arguments of the translation
+            for (Object arg : translatableContent.getArgs()) {
+                if (arg instanceof Text nestedText) {
+                    collectTranslationKeys(nestedText, keys); // Recursively handle nested Text
+                } else if (arg instanceof String stringArg) {
+                    keys.putIfAbsent(stringArg, null); // Treat plain strings as potential keys
+                }
+            }
+        }
+
+        // Collect keys from siblings (e.g., appended text)
+        for (Text sibling : text.getSiblings()) {
+            collectTranslationKeys(sibling, keys);
+        }
+    }
+
+    private static void populateTranslations(Map<String, String> keys) {
+        Language language = Language.getInstance(); // Client-side Language instance
+        for (Map.Entry<String, String> entry : keys.entrySet()) {
+            entry.setValue(language.get(entry.getKey(), entry.getKey())); // Fallback to key if translation is missing
+        }
+    }
+}

--- a/src/client/java/dev/creesch/util/ClientTranslationUtils.java
+++ b/src/client/java/dev/creesch/util/ClientTranslationUtils.java
@@ -10,7 +10,6 @@ public class ClientTranslationUtils {
 
     /**
      * Extracts all translation keys from a Text object and returns a map of key-value pairs with their translations.
-     * Works in a client-side environment.
      *
      * @param text The Text object to process.
      * @return A map where keys are translation keys and values are the corresponding translations.

--- a/src/client/resources/web/js/chat.mjs
+++ b/src/client/resources/web/js/chat.mjs
@@ -203,25 +203,34 @@ function handleChatMessage(message) {
         try {
             // Format the chat message - this uses the Component format from message_parsing
             assertIsComponent(message.payload.component);
-            const chatContent = formatChatMessage(message.payload.component);
+            const chatContent = formatChatMessage(
+                message.payload.component,
+                message.payload.translations,
+            );
             messageElement.appendChild(chatContent);
         } catch (e) {
             console.error(message);
             if (e instanceof ComponentError) {
                 console.error('Invalid component:', e.toString());
                 messageElement.appendChild(
-                    formatChatMessage({
-                        text: 'Invalid message received from server',
-                        color: 'red',
-                    }),
+                    formatChatMessage(
+                        {
+                            text: 'Invalid message received from server',
+                            color: 'red',
+                        },
+                        {},
+                    ),
                 );
             } else {
                 console.error('Error parsing message:', e);
                 messageElement.appendChild(
-                    formatChatMessage({
-                        text: 'Error parsing message',
-                        color: 'red',
-                    }),
+                    formatChatMessage(
+                        {
+                            text: 'Error parsing message',
+                            color: 'red',
+                        },
+                        {},
+                    ),
                 );
             }
         }

--- a/src/client/resources/web/js/messages/fallback_translations.mjs
+++ b/src/client/resources/web/js/messages/fallback_translations.mjs
@@ -1,9 +1,9 @@
 // @ts-check
 'use strict';
 
-// https://github.com/PrismarineJS/minecraft-data 1.21.1
+// 1.21.1 fallback translations for messages stored before database schema v2
 /** @type {Record<string, string>} */
-export const translations = {
+export const fallbackTranslations = {
     'accessibility.onboarding.accessibility.button':
         'Accessibility Settings...',
     'accessibility.onboarding.screen.narrator':

--- a/src/client/resources/web/js/messages/message_types.mjs
+++ b/src/client/resources/web/js/messages/message_types.mjs
@@ -26,6 +26,7 @@
  *   payload: {
  *     history: boolean,
  *     component: Component,
+ *     translations: Record<string, string>,
  *     uuid: string,
  *     isPing: boolean,
  *   }

--- a/src/test/resources/web/js/message_parsing.test.mjs
+++ b/src/test/resources/web/js/message_parsing.test.mjs
@@ -667,7 +667,7 @@ for (const [name, component, expected] of COMPONENT_FORMATTING_TESTS) {
     test(name, () => {
         expect(() => assertIsComponent(component)).not.toThrow();
 
-        const element = formatChatMessage(component);
+        const element = formatChatMessage(component, {});
         if (element instanceof Text) {
             expect(element.textContent).toBe(expected);
         } else {


### PR DESCRIPTION
Retrieve the translations directly when receiving messages and stores the translation alongside the message in the database. 
In the end I did opt for a 1 on 1 relation instead of storing translations in a different table and doing something with joins. This approach keeps things easier to follow, but there isn't always a clear relation with a minecraft version. For example, mods can have their own translation that can update independently of the minecraft version. 

I did debate trying to migrate all old messages with new translations. But, it turns out it is fairly difficult when you are not in the world/server the message belongs to.  In the end I figured it is much simpler to just use the current translations as a fallback. 