### PR TITLE
Make hover text render similar to in game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
             "name": "minecraft-web-chat",
             "devDependencies": {
                 "@eslint/js": "^9.17.0",
+                "@types/node": "^22.13.5",
                 "eslint": "^9.17.0",
                 "eslint-config-prettier": "^9.1.0",
                 "globals": "^15.14.0",
@@ -984,6 +985,16 @@
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "22.13.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+            "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.20.0"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.18.2",
@@ -3162,6 +3173,13 @@
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.8.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@types/node": "^22.13.5",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.14.0",

--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -8,6 +8,25 @@ body {
     overflow: hidden;
 }
 
+#hover-container {
+    font-family: 'JetBrains Mono', monospace;
+
+    display: none;
+    z-index: 1000;
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    border: 2px solid #0000aa;
+    outline: 2px solid black;
+    border-radius: 0.5rem;
+    color: #ffffff;
+    background-color: black;
+    padding: 0.5rem;
+
+    white-space: pre;
+}
+
 #container {
     height: 100vh;
     display: flex;

--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -17,11 +17,11 @@ body {
     top: 0;
     left: 0;
 
-    border: 2px solid #0000aa;
-    outline: 2px solid black;
+    border: 2px solid #25035c;
+    outline: 2px solid #130512;
     border-radius: 0.5rem;
     color: #ffffff;
-    background-color: black;
+    background-color: #130512;
     padding: 0.5rem;
 
     white-space: pre;

--- a/src/client/resources/web/index.html
+++ b/src/client/resources/web/index.html
@@ -26,6 +26,8 @@
         <link rel="stylesheet" href="css/message_formatting.css" />
     </head>
     <body>
+        <div id="hover-container" aria-hidden="true"></div>
+
         <main id="container">
             <section id="chat-area" aria-label="Chat messages and input">
                 <div id="tab-list" aria-label="Tab completion list">

--- a/src/client/resources/web/js/messages/message_parsing.mjs
+++ b/src/client/resources/web/js/messages/message_parsing.mjs
@@ -2,6 +2,7 @@
 'use strict';
 
 import { fallbackTranslations } from './fallback_translations.mjs';
+import { querySelectorWithAssertion } from '../utils.mjs';
 
 // Minecraft JSON message parsing to HTML.
 // A lot of the code below has been inspired (though not directly copied) by prismarine-chat: https://github.com/PrismarineJS/prismarine-chat
@@ -859,49 +860,10 @@ function formatTranslation(key, args, translations) {
 }
 
 /**
- * Separate plain text formatter for hover events where HTML isn't needed.
- * @param {Component} component
- * @param {Record<string, string>} translations
- * @returns {string}
- */
-function formatComponentPlainText(component, translations) {
-    let result = '';
-
-    if (component.text) {
-        result += component.text;
-    } else if (component.translate) {
-        result += formatTranslation(
-            component.translate,
-            component.with ?? [],
-            translations,
-        )
-            .map((component) => component.textContent ?? '')
-            .join('');
-    }
-
-    if (component.extra) {
-        result += component.extra
-            .map((component) => {
-                if (typeof component === 'string') {
-                    return component;
-                }
-                if (typeof component === 'number') {
-                    return String(component);
-                }
-
-                return formatComponentPlainText(component, translations);
-            })
-            .join('');
-    }
-
-    return result;
-}
-
-/**
  * Formats a hover event into a string.
  * @param {HoverEvent} hoverEvent
  * @param {Record<string, string>} translations
- * @returns {string}
+ * @returns {(Element | Text)[]}
  */
 function formatHoverEvent(hoverEvent, translations) {
     switch (hoverEvent.action) {
@@ -909,65 +871,65 @@ function formatHoverEvent(hoverEvent, translations) {
             const contents = hoverEvent.contents ?? hoverEvent.value;
             if (typeof contents === 'undefined') {
                 console.warn('HoverEvent.contents is undefined');
-                return '';
+                return [];
             }
 
             if (typeof contents === 'string') {
-                return contents;
+                return [document.createTextNode(contents)];
             }
             if (typeof contents === 'number') {
-                return String(contents);
+                return [document.createTextNode(String(contents))];
             }
 
             if (Array.isArray(contents)) {
-                return contents
-                    .map((component) => {
-                        if (typeof component === 'string') {
-                            return component;
-                        }
-                        if (typeof component === 'number') {
-                            return String(component);
-                        }
+                return contents.map((component) => {
+                    if (typeof component === 'string') {
+                        return document.createTextNode(component);
+                    }
+                    if (typeof component === 'number') {
+                        return document.createTextNode(String(component));
+                    }
 
-                        return formatComponentPlainText(
-                            component,
-                            translations,
-                        );
-                    })
-                    .join('');
+                    return formatComponent(component, translations);
+                });
             }
 
-            return formatComponentPlainText(contents, translations);
+            return [formatComponent(contents, translations)];
         }
         case 'show_item': {
             if (!hoverEvent.contents) {
                 // Don't attempt to parse SNBT data in hoverEvent.value
                 console.warn('Unsupported legacy hoverEvent');
-                return '';
+                return [];
             }
 
             if (hoverEvent.contents.count) {
-                return `${hoverEvent.contents.count}x ${hoverEvent.contents.id}`;
+                return [
+                    document.createTextNode(
+                        `${hoverEvent.contents.count}x ${hoverEvent.contents.id}`,
+                    ),
+                ];
             }
 
-            return hoverEvent.contents.id;
+            return [document.createTextNode(hoverEvent.contents.id)];
         }
 
         case 'show_entity': {
             if (!hoverEvent.contents) {
                 // Don't attempt to parse SNBT data in hoverEvent.value
                 console.warn('Unsupported legacy hoverEvent');
-                return '';
+                return [];
             }
 
             if (typeof hoverEvent.contents.name === 'object') {
-                return formatComponentPlainText(
-                    hoverEvent.contents.name,
-                    translations,
-                );
+                return [formatComponent(hoverEvent.contents.name, translations)];
             }
 
-            return hoverEvent.contents.name || 'Unnamed Entity';
+            return [
+                document.createTextNode(
+                    hoverEvent.contents.name || 'Unnamed Entity',
+                ),
+            ];
         }
     }
 }
@@ -1009,9 +971,35 @@ function formatComponent(component, translations) {
         result.classList.add('mc-obfuscated');
     }
 
-    // Hover events are implemented as titles for simplicity and broad browser compatibility
     if (component.hoverEvent) {
-        result.title = formatHoverEvent(component.hoverEvent, translations);
+        const hoverContents = formatHoverEvent(component.hoverEvent, translations);
+
+        if (hoverContents.length > 0) {
+            const hoverContainer = /** @type {HTMLDivElement} */ (
+                querySelectorWithAssertion('#hover-container')
+            );
+
+            result.ariaLabel = hoverContents
+                .map((component) => component.textContent)
+                .join(' ');
+
+            result.onmouseenter = (event) => {
+                hoverContainer.replaceChildren(...hoverContents);
+                hoverContainer.style.left = `${event.clientX}px`;
+                hoverContainer.style.top = `${event.clientY}px`;
+                hoverContainer.style.display = 'block';
+                hoverContainer.ariaHidden = 'false';
+            };
+            result.onmousemove = (event) => {
+                hoverContainer.style.left = `${event.clientX}px`;
+                hoverContainer.style.top = `${event.clientY}px`;
+            };
+            result.onmouseleave = () => {
+                hoverContainer.style.display = 'none';
+                hoverContainer.replaceChildren();
+                hoverContainer.ariaHidden = 'true';
+            };
+        }
     }
 
     if (component.text) {

--- a/src/client/resources/web/js/messages/message_parsing.mjs
+++ b/src/client/resources/web/js/messages/message_parsing.mjs
@@ -988,7 +988,6 @@ function formatComponent(component, translations) {
                 hoverContainer.style.left = `${event.clientX}px`;
                 hoverContainer.style.top = `${event.clientY}px`;
                 hoverContainer.style.display = 'block';
-                hoverContainer.ariaHidden = 'false';
             };
             result.onmousemove = (event) => {
                 hoverContainer.style.left = `${event.clientX}px`;
@@ -997,7 +996,6 @@ function formatComponent(component, translations) {
             result.onmouseleave = () => {
                 hoverContainer.style.display = 'none';
                 hoverContainer.replaceChildren();
-                hoverContainer.ariaHidden = 'true';
             };
         }
     }

--- a/src/client/resources/web/js/messages/message_parsing.mjs
+++ b/src/client/resources/web/js/messages/message_parsing.mjs
@@ -922,7 +922,9 @@ function formatHoverEvent(hoverEvent, translations) {
             }
 
             if (typeof hoverEvent.contents.name === 'object') {
-                return [formatComponent(hoverEvent.contents.name, translations)];
+                return [
+                    formatComponent(hoverEvent.contents.name, translations),
+                ];
             }
 
             return [
@@ -972,7 +974,10 @@ function formatComponent(component, translations) {
     }
 
     if (component.hoverEvent) {
-        const hoverContents = formatHoverEvent(component.hoverEvent, translations);
+        const hoverContents = formatHoverEvent(
+            component.hoverEvent,
+            translations,
+        );
 
         if (hoverContents.length > 0) {
             const hoverContainer = /** @type {HTMLDivElement} */ (

--- a/src/test/resources/web/js/message_parsing.test.mjs
+++ b/src/test/resources/web/js/message_parsing.test.mjs
@@ -8,10 +8,7 @@ import {
  * @typedef {import('~/messages/message_parsing.mjs').Component} Component
  */
 
-const indexDocument = new DOMParser().parseFromString(
-    readFileSync('src/client/resources/web/index.html', 'utf-8'),
-    'text/html',
-);
+const indexHTML = readFileSync('src/client/resources/web/index.html', 'utf-8');
 
 /**
  * @type {readonly [string, unknown, string | undefined][]}
@@ -673,7 +670,7 @@ for (const [name, component, expected] of COMPONENT_FORMATTING_TESTS) {
     test(name, () => {
         // Initialize the DOM for each test
         // eslint-disable-next-line no-global-assign
-        document = indexDocument;
+        document = new DOMParser().parseFromString(indexHTML, 'text/html');
 
         expect(() => assertIsComponent(component)).not.toThrow();
 

--- a/src/test/resources/web/js/message_parsing.test.mjs
+++ b/src/test/resources/web/js/message_parsing.test.mjs
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { expect, test } from 'vitest';
 import {
     assertIsComponent,
@@ -6,6 +7,11 @@ import {
 /**
  * @typedef {import('~/messages/message_parsing.mjs').Component} Component
  */
+
+const indexDocument = new DOMParser().parseFromString(
+    readFileSync('src/client/resources/web/index.html', 'utf-8'),
+    'text/html',
+);
 
 /**
  * @type {readonly [string, unknown, string | undefined][]}
@@ -450,7 +456,7 @@ const COMPONENT_FORMATTING_TESTS = [
             text: 'hover',
             hoverEvent: { action: 'show_text', contents: 'tooltip' },
         },
-        '<span title="tooltip">hover</span>',
+        '<span aria-label="tooltip">hover</span>',
     ],
     [
         'hover item',
@@ -461,7 +467,7 @@ const COMPONENT_FORMATTING_TESTS = [
                 contents: { id: 'minecraft:diamond' },
             },
         },
-        '<span title="minecraft:diamond">item</span>',
+        '<span aria-label="minecraft:diamond">item</span>',
     ],
     [
         'hover item with count',
@@ -472,7 +478,7 @@ const COMPONENT_FORMATTING_TESTS = [
                 contents: { id: 'minecraft:diamond', count: 64 },
             },
         },
-        '<span title="64x minecraft:diamond">items</span>',
+        '<span aria-label="64x minecraft:diamond">items</span>',
     ],
     [
         'hover entity',
@@ -483,12 +489,12 @@ const COMPONENT_FORMATTING_TESTS = [
                 contents: { type: 'minecraft:pig', id: '123', name: 'Mr. Pig' },
             },
         },
-        '<span title="Mr. Pig">entity</span>',
+        '<span aria-label="Mr. Pig">entity</span>',
     ],
     [
         'hover text with number',
         { text: 'hover', hoverEvent: { action: 'show_text', contents: 42 } },
-        '<span title="42">hover</span>',
+        '<span aria-label="42">hover</span>',
     ],
 
     // Complex nested components
@@ -590,7 +596,7 @@ const COMPONENT_FORMATTING_TESTS = [
             'Found item: ' +
             '<span class="mc-italic">' +
             "Unknown item '" +
-            '<span class="mc-aqua" title="1x minecraft:diamond_pickaxe">' +
+            '<span class="mc-aqua" aria-label="1x minecraft:diamond_pickaxe">' +
             'diamond_pickaxe' +
             "</span>'" +
             '</span>' +
@@ -665,6 +671,10 @@ const COMPONENT_FORMATTING_TESTS = [
 
 for (const [name, component, expected] of COMPONENT_FORMATTING_TESTS) {
     test(name, () => {
+        // Initialize the DOM for each test
+        // eslint-disable-next-line no-global-assign
+        document = indexDocument;
+
         expect(() => assertIsComponent(component)).not.toThrow();
 
         const element = formatChatMessage(component, {});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "lib": ["dom", "ES2021"],
+        "types": ["node"],
 
         // JavaScript Support
         "allowJs": true,


### PR DESCRIPTION
https://github.com/user-attachments/assets/2b52065f-9813-44c3-be96-de7235a0bb8d

I'm using `aria-label` as a bit of a hack for testing the result of `formatHoverEvent()` because now the elements it returns are held in closure state instead of within the DOM.