### PR TITLE
Fix clicking on username in tab complete

### DIFF
--- a/src/client/resources/web/js/managers/tab_list_manager.mjs
+++ b/src/client/resources/web/js/managers/tab_list_manager.mjs
@@ -170,12 +170,13 @@ class TabListManager {
                 .slice(0, 5)
                 .map((match, index) => {
                     const li = document.createElement('li');
-                    li.addEventListener('click', () =>
-                        this.#insertPlayerName(),
-                    );
-                    li.addEventListener('mouseenter', () =>
-                        this.#updateSelection(index),
-                    );
+                    // Using mousedown because clicking causes blur event on chat input hiding the selection.
+                    li.addEventListener('mousedown', () => {
+                        this.#insertPlayerName();
+                    });
+                    li.addEventListener('mouseenter', () => {
+                        this.#updateSelection(index);
+                    });
 
                     const displayNameUnchanged =
                         match.playerDisplayName.toLocaleLowerCase() ===


### PR DESCRIPTION
Clicking on usernames in tab complete did not work as it was using a click event. The click event causes a blur event on the chat input, which is used to hide the tab list. 

```
// Hide tablist when textarea loses focus
chatInputElement.addEventListener('blur', function () {
    tabListManager.hide();
});
``` 

Causing the click to never be processed properly. Switching to a mousedown event fixes this. 
