### PR TITLE
Workaround `Text` instances that can't be serialized to JSON

### DIFF
--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -1,8 +1,6 @@
 package dev.creesch.model;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
@@ -15,12 +13,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
@@ -50,14 +43,27 @@ public class WebsocketMessageBuilder {
             );
         }
 
-        Map<String, String> translations =
-            ClientTranslationUtils.extractTranslations(message);
-
         // Can't use GSON for Text serialization easily, using Minecraft's own serializer.
-        String minecraftChatJson = Text.Serialization.toJsonString(
-            message,
-            client.world.getRegistryManager()
-        );
+        // The try block is used as there are instances of `Text` that can't be serialized to JSON
+        Map<String, String> translations;
+        String minecraftChatJson;
+
+        try {
+            translations =
+                ClientTranslationUtils.extractTranslations(message);
+
+            minecraftChatJson = Text.Serialization.toJsonString(
+                message,
+                client.world.getRegistryManager()
+            );
+        } catch (JsonParseException exception) {
+            LOGGER.warn("Failed to serialize chat message: " + message.getString());
+            LOGGER.warn("Exception info: ", exception);
+
+            // Get plain string message and show as error in chat.
+            minecraftChatJson = "{\"text\":\"Could not convert message: %s\"}".formatted(message.getString());
+            translations = Map.of();
+        }
 
         // Explicitly use UTC time for consistency across different timezones
         long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
@@ -70,10 +76,11 @@ public class WebsocketMessageBuilder {
         ).toString();
 
         // Back to objects we go
+        JsonObject jsonObject= gson.fromJson(minecraftChatJson, JsonObject.class);
         ChatMessagePayload messageObject = ChatMessagePayload.builder()
             .history(false)
             .uuid(messageUUID)
-            .component(gson.fromJson(minecraftChatJson, JsonObject.class))
+            .component(jsonObject)
             .isPing(!fromSelf && isPing(message, client))
             .translations(translations)
             .build();

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -49,19 +49,23 @@ public class WebsocketMessageBuilder {
         String minecraftChatJson;
 
         try {
-            translations =
-                ClientTranslationUtils.extractTranslations(message);
+            translations = ClientTranslationUtils.extractTranslations(message);
 
             minecraftChatJson = Text.Serialization.toJsonString(
                 message,
                 client.world.getRegistryManager()
             );
         } catch (JsonParseException exception) {
-            LOGGER.warn("Failed to serialize chat message: " + message.getString());
+            LOGGER.warn(
+                "Failed to serialize chat message: " + message.getString()
+            );
             LOGGER.warn("Exception info: ", exception);
 
             // Get plain string message and show as error in chat.
-            minecraftChatJson = "{\"text\":\"Could not convert message: %s\"}".formatted(message.getString());
+            minecraftChatJson =
+                "{\"text\":\"Could not convert message: %s\"}".formatted(
+                        message.getString()
+                    );
             translations = Map.of();
         }
 
@@ -76,7 +80,10 @@ public class WebsocketMessageBuilder {
         ).toString();
 
         // Back to objects we go
-        JsonObject jsonObject= gson.fromJson(minecraftChatJson, JsonObject.class);
+        JsonObject jsonObject = gson.fromJson(
+            minecraftChatJson,
+            JsonObject.class
+        );
         ChatMessagePayload messageObject = ChatMessagePayload.builder()
             .history(false)
             .uuid(messageUUID)


### PR DESCRIPTION
I had minecraft crash a few times being caused by me activating a specific feature in freecam. This feature send a `Text` message that causes a `JsonParseException` when we try to parse it. 

```java
com.google.gson.JsonParseException: This value needs to be parsed as component
	at knot/com.mojang.serialization.DataResult$Error.mdae6d3d$owo$lambda$addStackTraceToException$0$0(DataResult.java:584) ~[datafixerupper-8.0.16.jar:?]
	at knot/com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287) ~[datafixerupper-8.0.16.jar:?]
	at knot/net.minecraft.class_2561$class_2562.method_10874(class_2561.java:167) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_2561$class_2562.method_10867(class_2561.java:173) ~[client-intermediary.jar:?]
	at knot/dev.creesch.model.WebsocketMessageBuilder.createLiveChatMessage(WebsocketMessageBuilder.java:58) ~[web-chat-1.2.0.jar:?]
	at knot/dev.creesch.WebchatClient.lambda$onInitializeClient$1(WebchatClient.java:75) ~[web-chat-1.2.0.jar:?]
	at knot/net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents.lambda$static$8(ClientReceiveMessageEvents.java:124) ~[fabric-message-api-v1-6.0.25+7feeb73304-99f782ae230989d7.jar:?]
	at knot/net.minecraft.class_7594.handler$zlh000$fabric-message-api-v1$fabric_allowGameMessage(class_7594.java:574) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_7594.method_44736(class_7594.java) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_746.method_7353(class_746.java:425) ~[client-intermediary.jar:?]
	at knot/net.xolt.freecam.Freecam.onDisableTripod(Freecam.java:214) ~[freecam-fabric-1.3.2+mc1.21.4.jar:?]
	at knot/net.xolt.freecam.Freecam.toggleTripod(Freecam.java:144) ~[freecam-fabric-1.3.2+mc1.21.4.jar:?]
	at knot/net.xolt.freecam.Freecam.toggle(Freecam.java:115) ~[freecam-fabric-1.3.2+mc1.21.4.jar:?]
	at knot/net.xolt.freecam.config.keys.FreecamComboKeyMapping.method_4622(FreecamComboKeyMapping.java:38) ~[freecam-fabric-1.3.2+mc1.21.4.jar:?]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310) ~[?:?]
	at java.base/java.util.Spliterators$1Adapter.forEachRemaining(Spliterators.java:706) ~[?:?]
	at knot/net.xolt.freecam.config.ModBindings.forEach(ModBindings.java:61) ~[freecam-fabric-1.3.2+mc1.21.4.jar:?]
	at knot/net.xolt.freecam.Freecam.postTick(Freecam.java:70) ~[freecam-fabric-1.3.2+mc1.21.4.jar:?]
	at knot/net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.lambda$static$2(ClientTickEvents.java:43) ~[fabric-lifecycle-events-v1-2.5.4+bf2a60eb04-b4ff52bc5028a975.jar:?]
	at knot/net.minecraft.class_310.handler$zla000$fabric-lifecycle-events-v1$onEndTick(class_310.java:7081) [client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1574(class_310.java:1940) [client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1523(class_310.java:1302) [client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1514(class_310.java:922) [client-intermediary.jar:?]
	at knot/net.minecraft.client.main.Main.main(Main.java:267) [client-intermediary.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480) [fabric-loader-0.16.10.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.16.10.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.16.10.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
```	

Since this seems to be an edge case and I am not even sure it isn't freecam doing things wrong I didn't bother (for now) trying to serialize it in a different way. Instead we are just catching the error and showing the plain text message. 