### PR TITLE
Do not clear messages on disconnect

### DIFF
--- a/src/client/resources/web/js/chat.mjs
+++ b/src/client/resources/web/js/chat.mjs
@@ -352,7 +352,6 @@ function handleMinecraftServerConnectionState(message) {
             console.log('Received disconnect event. Sad to see you go.');
             serverInfo.clear();
             playerList.clearAll();
-            clearMessageHistory();
             break;
     }
 }


### PR DESCRIPTION
After playing with it for a bit, I don't like clearing messages on disconnect. People might want to reference something in chat when they are disconnected. Even more so because we don't know if the disconnect event was on purpose. So, keeping it around makes sense to me. 