### PR TITLE
Fix word-breaking

### DIFF
--- a/src/client/resources/web/css/main.css
+++ b/src/client/resources/web/css/main.css
@@ -266,7 +266,7 @@ body {
 .message {
     position: relative;
     padding: 0.5rem;
-    word-wrap: break-word;
+    word-break: break-word;
     white-space: pre-wrap;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
I noticed on my phone that long words were not breaking and so the message container could gain a horizontal scroll bar.