### PR TITLE
Update GitHub workflow to use setup-gradle@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,13 @@ jobs:
         steps:
             - name: checkout repository
               uses: actions/checkout@v4
-            - name: validate gradle wrapper
-              uses: gradle/wrapper-validation-action@v2
             - name: setup jdk ${{ matrix.java }}
               uses: actions/setup-java@v4
               with:
                   java-version: ${{ matrix.java }}
                   distribution: 'microsoft'
-            - name: make gradle wrapper executable
-              run: chmod +x ./gradlew
+            - name: setup gradle
+              uses: gradle/actions/setup-gradle@v4
             - name: build
               run: ./gradlew build
             - name: capture build artifacts


### PR DESCRIPTION
https://github.com/gradle/actions/tree/main/setup-gradle

Note that this implicitly validates the gradle wrapper. See https://github.com/gradle/actions/tree/main/wrapper-validation