### PR TITLE
Refactor Text to Json parsing fixes #148

### DIFF
--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -68,9 +68,10 @@ public class WebsocketMessageBuilder {
 
             // Get plain string message and show as error in chat.
             minecraftChatJsonObject = new JsonObject();
-            minecraftChatJsonObject.addProperty("text", "Could not convert message: %s".formatted(
-                message.getString()
-            ));
+            minecraftChatJsonObject.addProperty(
+                "text",
+                "Could not convert message: %s".formatted(message.getString())
+            );
             translations = Map.of();
         }
 
@@ -383,9 +384,12 @@ public class WebsocketMessageBuilder {
 
                     // Get plain string displayName and display that.
                     minecraftJsonObjectDisplayName = new JsonObject();
-                    minecraftJsonObjectDisplayName.addProperty("text", "Could not convert message: %s".formatted(
-                        playerDisplayName.getString()
-                    ));
+                    minecraftJsonObjectDisplayName.addProperty(
+                        "text",
+                        "Could not convert message: %s".formatted(
+                                playerDisplayName.getString()
+                            )
+                    );
                 }
 
                 // To get the texture we need to digg a little bit deeper.


### PR DESCRIPTION
Skip the string conversion in the fallback. Avoiding any issues with quotes and other characters. 
Use a fallback for primitives directly. 

Tested with a variety of servers found here: https://findmcserver.com/servers/1.21.8 

