### PR TITLE
Upgrade to MC 26.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,7 @@ jobs:
     build:
         strategy:
             matrix:
-                # Use these Java versions
-                java: [
-                        21, # Current Java LTS
-                    ]
+                java: [25]
         runs-on: ubuntu-24.04
         steps:
             - name: checkout repository
@@ -31,7 +28,7 @@ jobs:
             - name: build
               run: ./gradlew build
             - name: capture build artifacts
-              if: ${{ matrix.java == '21' }} # Only upload artifacts built from latest java
+              if: ${{ matrix.java == '25' }} # Only upload artifacts built from latest java
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,24 +11,22 @@ on:
 
 jobs:
     build:
-        strategy:
-            matrix:
-                java: [25]
         runs-on: ubuntu-24.04
+        env:
+            JAVA_VERSION: 25
         steps:
             - name: checkout repository
               uses: actions/checkout@v4
-            - name: setup jdk ${{ matrix.java }}
+            - name: setup jdk ${{ env.JAVA_VERSION }}
               uses: actions/setup-java@v4
               with:
-                  java-version: ${{ matrix.java }}
+                  java-version: ${{ env.JAVA_VERSION }}
                   distribution: 'microsoft'
             - name: setup gradle
               uses: gradle/actions/setup-gradle@v4
             - name: build
               run: ./gradlew build
             - name: capture build artifacts
-              if: ${{ matrix.java == '25' }} # Only upload artifacts built from latest java
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 }
 
 plugins {
-	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version '1.16-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.gradleup.shadow' version '9.4.1'
 }
@@ -40,12 +40,11 @@ configurations {
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
-	modImplementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
+	implementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
+	implementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
 
 	// Java dependencies
 	// Compile only
@@ -57,7 +56,7 @@ dependencies {
 	shadow "io.javalin:javalin:${project.javalin_version}"
 
     implementation "org.xerial:sqlite-jdbc:${project.xerial_version}"
-    include "org.xerial:sqlite-jdbc:${project.xerial_version}"
+    shadow "org.xerial:sqlite-jdbc:${project.xerial_version}"
 
 }
 
@@ -74,7 +73,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
@@ -83,8 +82,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 
@@ -101,23 +100,20 @@ shadowJar {
 	from sourceSets.main.output
     from sourceSets.client.output
     configurations = [project.configurations.shadow] // Include shadow dependencies
-    archiveClassifier.set("shadow") // Make sure we end up with just one unified jar
+    archiveClassifier.set("") // Produce the final JAR without classifier
 
     // Relocate dependencies to avoid conflicts
     relocate "io.javalin", "dev.creesch.shadow.io.javalin"
     relocate "org.eclipse.jetty", "dev.creesch.shadow.jetty"
 
-	minimize()
+	minimize {
+		// SQLite loads its driver/native code via reflection; keep the whole jar.
+		exclude(dependency("org.xerial:sqlite-jdbc:.*"))
+	}
 
 }
 
-remapJar {
-    dependsOn shadowJar
-    inputFile.set(shadowJar.archiveFile)
-    archiveClassifier.set("") // Produce the final remapped JAR without classifier
-}
-
-tasks.assemble.dependsOn remapJar
+tasks.assemble.dependsOn shadowJar
 
 // configure the maven publication
 publishing {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,9 +2,9 @@
 ext {
     // Fabric Properties
     // check these on https://fabricmc.net/develop
-    minecraft_version = '1.21.11'
-    yarn_mappings = '1.21.11+build.3'
-    loader_version = '0.18.4'
+    minecraft_version = '26.1.2'
+    loader_version = '0.18.6'
+    loom_version = '1.16-SNAPSHOT'
 
     // Mod Properties
     mod_version = '1.6.0'
@@ -12,9 +12,9 @@ ext {
     archives_base_name = 'web-chat'
 
     // Dependencies
-    fabric_version = '0.140.2+1.21.11'
-    yacl_version = '3.8.1+1.21.11-fabric'
-    mod_menu_version = '17.0.0-beta.1'
+    fabric_version = '0.145.4+26.1.2'
+    yacl_version = '3.9.2+26.1-fabric'
+    mod_menu_version = '18.0.0-alpha.8'
 
     // Generic java dependencies
     javalin_version = '7.1.0'

--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import lombok.Getter;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
 
 public class WebInterface {
 
@@ -236,8 +236,8 @@ public class WebInterface {
 
                 // If minecraft is connected to a server the client needs to know.
                 // Client should never be null, but again better safe than sorry.
-                MinecraftClient client = MinecraftClient.getInstance();
-                if (client == null || client.world == null) {
+                Minecraft client = Minecraft.getInstance();
+                if (client == null || client.level == null) {
                     return;
                 }
                 // Got a world, use JOIN state to communicate this
@@ -382,7 +382,7 @@ public class WebInterface {
     }
 
     private void sendMinecraftMessage(String message) {
-        MinecraftClient client = MinecraftClient.getInstance();
+        Minecraft client = Minecraft.getInstance();
         // Probably an edge case, if even possible but client can potentially be null
         if (client == null) {
             LOGGER.warn(
@@ -392,7 +392,7 @@ public class WebInterface {
         }
 
         client.execute(() -> {
-            ClientPlayerEntity player = client.player;
+            LocalPlayer player = client.player;
             if (player == null) {
                 LOGGER.warn("Player value is null. Cannot send message.");
                 return;
@@ -406,23 +406,21 @@ public class WebInterface {
                     maxLength + slash.length()
                 );
                 // Remove the leading slash and truncate to maxLength.
-                player.networkHandler.sendChatCommand(
+                player.connection.sendCommand(
                     message.substring(slash.length(), end)
                 );
                 return;
             }
 
             if (message.length() <= maxLength) {
-                player.networkHandler.sendChatMessage(message);
+                player.connection.sendChat(message);
                 return;
             }
 
             // Break long messages into smaller chunks
             for (int i = 0; i < message.length(); i += maxLength) {
                 int end = Math.min(i + maxLength, message.length());
-                player.networkHandler.sendChatMessage(
-                    message.substring(i, end)
-                );
+                player.connection.sendChat(message.substring(i, end));
             }
         });
     }

--- a/src/client/java/dev/creesch/WebchatClient.java
+++ b/src/client/java/dev/creesch/WebchatClient.java
@@ -13,10 +13,10 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 
 public class WebchatClient implements ClientModInitializer {
 
@@ -52,7 +52,7 @@ public class WebchatClient implements ClientModInitializer {
         // Chat messages from users.
         ClientReceiveMessageEvents.CHAT.register(
             (message, signedMessage, sender, params, receptionTimestamp) -> {
-                MinecraftClient client = MinecraftClient.getInstance();
+                Minecraft client = Minecraft.getInstance();
                 String selfName =
                     client.player == null
                         ? ""
@@ -82,7 +82,7 @@ public class WebchatClient implements ClientModInitializer {
                     WebsocketMessageBuilder.createLiveChatMessage(
                         message,
                         false,
-                        MinecraftClient.getInstance()
+                        Minecraft.getInstance()
                     );
                 messageRepository.saveMessage(chatMessage);
                 webInterface.broadcastMessage(chatMessage);
@@ -158,7 +158,7 @@ public class WebchatClient implements ClientModInitializer {
         // works out to just send clients updates every couple of ticks.
         ClientTickEvents.END_CLIENT_TICK.register((client) -> {
             // Only used to send player list updates. So a client is needed and a world (on a server)
-            if (client == null || client.world == null) {
+            if (client == null || client.level == null) {
                 return;
             }
 
@@ -197,7 +197,7 @@ public class WebchatClient implements ClientModInitializer {
             INSTANCE.webInterface = new WebInterface(
                 INSTANCE.messageRepository
             );
-            INSTANCE.showWebAddress(MinecraftClient.getInstance());
+            INSTANCE.showWebAddress(Minecraft.getInstance());
         }
     }
 
@@ -205,17 +205,17 @@ public class WebchatClient implements ClientModInitializer {
         return MOD_VERSION;
     }
 
-    private void showWebAddress(MinecraftClient client) {
+    private void showWebAddress(Minecraft client) {
         if (client == null || client.player == null) {
             return;
         }
         String webchatPort = String.valueOf(
             ModConfig.HANDLER.instance().httpPortNumber
         );
-        Text message = Text.literal("Web chat: ").append(
-            Text.literal("http://localhost:" + webchatPort)
-                .formatted(Formatting.BLUE, Formatting.UNDERLINE)
-                .styled((style) ->
+        Component message = Component.literal("Web chat: ").append(
+            Component.literal("http://localhost:" + webchatPort)
+                .withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE)
+                .withStyle((style) ->
                     style.withClickEvent(
                         new ClickEvent.OpenUrl(
                             URI.create("http://localhost:" + webchatPort)
@@ -223,6 +223,6 @@ public class WebchatClient implements ClientModInitializer {
                     )
                 )
         );
-        client.player.sendMessage(message, false);
+        client.player.sendSystemMessage(message);
     }
 }

--- a/src/client/java/dev/creesch/config/ModConfig.java
+++ b/src/client/java/dev/creesch/config/ModConfig.java
@@ -7,13 +7,13 @@ import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import java.util.Arrays;
 import java.util.List;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 
 public class ModConfig {
 
     public static ConfigClassHandler<ModConfig> HANDLER =
         ConfigClassHandler.createBuilder(ModConfig.class)
-            .id(Identifier.of("web-chat", "web-config"))
+            .id(Identifier.fromNamespaceAndPath("web-chat", "web-config"))
             .serializer((config) ->
                 GsonConfigSerializerBuilder.create(config)
                     .setPath(

--- a/src/client/java/dev/creesch/config/ModConfigScreen.java
+++ b/src/client/java/dev/creesch/config/ModConfigScreen.java
@@ -5,29 +5,29 @@ import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.controller.BooleanControllerBuilder;
 import dev.isxander.yacl3.api.controller.IntegerFieldControllerBuilder;
 import dev.isxander.yacl3.api.controller.StringControllerBuilder;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 
 public class ModConfigScreen {
 
     public static Screen createScreen(Screen parent) {
         YetAnotherConfigLib.Builder builder =
             YetAnotherConfigLib.createBuilder().title(
-                Text.literal("Web Chat Configuration")
+                Component.literal("Web Chat Configuration")
             );
 
         builder.category(
             ConfigCategory.createBuilder()
-                .name(Text.literal("Message Settings"))
+                .name(Component.literal("Message Settings"))
                 .group(
                     OptionGroup.createBuilder()
-                        .name(Text.literal("Ping Settings"))
+                        .name(Component.literal("Ping Settings"))
                         .option(
                             Option.<Boolean>createBuilder()
-                                .name(Text.literal("Ping on Username"))
+                                .name(Component.literal("Ping on Username"))
                                 .description(
                                     OptionDescription.of(
-                                        Text.literal(
+                                        Component.literal(
                                             "Enable ping on username.\n" +
                                                 "This will ping the browser window any time a player's username appears in the chat " +
                                                 "(case insensitive)."
@@ -49,10 +49,10 @@ public class ModConfigScreen {
                 )
                 .group(
                     ListOption.<String>createBuilder()
-                        .name(Text.literal("Extra Ping Keywords"))
+                        .name(Component.literal("Extra Ping Keywords"))
                         .description(
                             OptionDescription.of(
-                                Text.literal(
+                                Component.literal(
                                     "Extra keywords to ping on.\n" +
                                         "This will ping the browser window any time one of these words appear in the chat " +
                                         "(case insensitive)."
@@ -74,16 +74,16 @@ public class ModConfigScreen {
 
         builder.category(
             ConfigCategory.createBuilder()
-                .name(Text.literal("Network Settings"))
+                .name(Component.literal("Network Settings"))
                 .group(
                     OptionGroup.createBuilder()
-                        .name(Text.literal("Port Settings"))
+                        .name(Component.literal("Port Settings"))
                         .option(
                             Option.<Integer>createBuilder()
-                                .name(Text.literal("HTTP Port"))
+                                .name(Component.literal("HTTP Port"))
                                 .description(
                                     OptionDescription.of(
-                                        Text.literal(
+                                        Component.literal(
                                             "Port number used to serve the web interface.\n" +
                                                 "Make sure that this port is available."
                                         )
@@ -101,7 +101,9 @@ public class ModConfigScreen {
                                     IntegerFieldControllerBuilder.create(opt)
                                         .range(1024, 65535)
                                         .formatValue((value) ->
-                                            Text.literal(String.valueOf(value))
+                                            Component.literal(
+                                                String.valueOf(value)
+                                            )
                                         )
                                 )
                                 .build()
@@ -114,16 +116,16 @@ public class ModConfigScreen {
         if (ModConfig.HANDLER.instance().developmentMode) {
             builder.category(
                 ConfigCategory.createBuilder()
-                    .name(Text.literal("Development Settings"))
+                    .name(Component.literal("Development Settings"))
                     .group(
                         OptionGroup.createBuilder()
-                            .name(Text.literal("Static Files Path"))
+                            .name(Component.literal("Static Files Path"))
                             .option(
                                 Option.<String>createBuilder()
-                                    .name(Text.literal("Path"))
+                                    .name(Component.literal("Path"))
                                     .description(
                                         OptionDescription.of(
-                                            Text.literal(
+                                            Component.literal(
                                                 "Path to the static files for the web interface.\n" +
                                                     "Leave blank to use files included in the mod jar."
                                             )

--- a/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
+++ b/src/client/java/dev/creesch/model/WebsocketMessageBuilder.java
@@ -17,11 +17,11 @@ import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.registry.RegistryWrapper;
-import net.minecraft.text.Text;
-import net.minecraft.text.TextCodecs;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
 
 public class WebsocketMessageBuilder {
 
@@ -36,11 +36,11 @@ public class WebsocketMessageBuilder {
      * @param client The Minecraft client instance
      */
     public static WebsocketJsonMessage createLiveChatMessage(
-        Text message,
+        Component message,
         boolean fromSelf,
-        MinecraftClient client
+        Minecraft client
     ) {
-        if (client.world == null) {
+        if (client.level == null) {
             throw new MessageBuildException(
                 "Cannot create chat message: client world is null"
             );
@@ -55,7 +55,7 @@ public class WebsocketMessageBuilder {
             translations = ClientTranslationUtils.extractTranslations(message);
             minecraftChatJsonObject = toJsonObject(
                 message,
-                client.world.getRegistryManager()
+                client.level.registryAccess()
             );
         } catch (JsonParseException exception) {
             LOGGER.warn(
@@ -76,7 +76,7 @@ public class WebsocketMessageBuilder {
         long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
         WebsocketJsonMessage.ChatServerInfo serverInfo =
             MinecraftServerIdentifier.getCurrentServerInfo();
-        String minecraftVersion = SharedConstants.getGameVersion().name();
+        String minecraftVersion = SharedConstants.getCurrentVersion().name();
         // UUID used to prevent duplicates
         String messageUUID = UUID.nameUUIDFromBytes(
             (timestamp + gson.toJson(minecraftChatJsonObject)).getBytes()
@@ -106,11 +106,11 @@ public class WebsocketMessageBuilder {
      * @return JsonObject representation of the message
      */
     private static JsonObject toJsonObject(
-        Text message,
-        RegistryWrapper.WrapperLookup registries
+        Component message,
+        HolderLookup.Provider registries
     ) {
-        JsonElement jsonElement = TextCodecs.CODEC.encodeStart(
-            registries.getOps(JsonOps.INSTANCE),
+        JsonElement jsonElement = ComponentSerialization.CODEC.encodeStart(
+            registries.createSerializationContext(JsonOps.INSTANCE),
             message
         ).getOrThrow(JsonParseException::new);
 
@@ -123,7 +123,9 @@ public class WebsocketMessageBuilder {
             return jsonObject;
         } else {
             // For anything else assume it isn't Minecraft chat format that can be parsed down the line.
-            throw new JsonParseException("Cannot create JSON object from Text");
+            throw new JsonParseException(
+                "Cannot create JSON object from Component"
+            );
         }
     }
 
@@ -134,7 +136,7 @@ public class WebsocketMessageBuilder {
      * @param client The Minecraft client instance
      * @return True if the message is a ping, false otherwise
      */
-    private static boolean isPing(Text message, MinecraftClient client) {
+    private static boolean isPing(Component message, Minecraft client) {
         String messageString = message.getString();
         ModConfig config = ModConfig.HANDLER.instance();
 
@@ -237,7 +239,7 @@ public class WebsocketMessageBuilder {
         long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
         WebsocketJsonMessage.ChatServerInfo serverInfo =
             MinecraftServerIdentifier.getCurrentServerInfo();
-        String minecraftVersion = SharedConstants.getGameVersion().id();
+        String minecraftVersion = SharedConstants.getCurrentVersion().id();
 
         return WebsocketJsonMessage.createServerConnectionStateMessage(
             timestamp,
@@ -269,7 +271,7 @@ public class WebsocketMessageBuilder {
         long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
         WebsocketJsonMessage.ChatServerInfo serverInfo =
             MinecraftServerIdentifier.getCurrentServerInfo();
-        String minecraftVersion = SharedConstants.getGameVersion().id();
+        String minecraftVersion = SharedConstants.getCurrentVersion().id();
 
         return WebsocketJsonMessage.createHistoryMetaDataMessage(
             timestamp,
@@ -343,10 +345,8 @@ public class WebsocketMessageBuilder {
      *
      * @param client MinecraftClient
      */
-    public static WebsocketJsonMessage createPlayerList(
-        MinecraftClient client
-    ) {
-        ClientPlayNetworkHandler networkHandler = client.getNetworkHandler();
+    public static WebsocketJsonMessage createPlayerList(Minecraft client) {
+        ClientPacketListener networkHandler = client.getConnection();
 
         List<PlayerListInfoEntry> playerList = new ArrayList<>();
 
@@ -354,21 +354,21 @@ public class WebsocketMessageBuilder {
             return null;
         }
         networkHandler
-            .getPlayerList()
+            .getOnlinePlayers()
             .forEach((player) -> {
                 GameProfile profile = player.getProfile(); // Contains UUID and name
                 String playerId = profile.id().toString();
                 String playerName = profile.name();
 
-                Text playerDisplayName =
-                    player.getDisplayName() != null
-                        ? player.getDisplayName()
-                        : Text.literal(playerName);
+                Component playerDisplayName =
+                    player.getTabListDisplayName() != null
+                        ? player.getTabListDisplayName()
+                        : Component.literal(playerName);
                 JsonObject minecraftJsonObjectDisplayName;
                 try {
                     minecraftJsonObjectDisplayName = toJsonObject(
                         playerDisplayName,
-                        client.world.getRegistryManager()
+                        client.level.registryAccess()
                     );
                 } catch (JsonParseException exception) {
                     LOGGER.warn(
@@ -407,7 +407,7 @@ public class WebsocketMessageBuilder {
         long timestamp = Instant.now(Clock.systemUTC()).toEpochMilli();
         WebsocketJsonMessage.ChatServerInfo serverInfo =
             MinecraftServerIdentifier.getCurrentServerInfo();
-        String minecraftVersion = SharedConstants.getGameVersion().id();
+        String minecraftVersion = SharedConstants.getCurrentVersion().id();
 
         return WebsocketJsonMessage.createServerPlayerListMessage(
             timestamp,

--- a/src/client/java/dev/creesch/util/ClientTranslationUtils.java
+++ b/src/client/java/dev/creesch/util/ClientTranslationUtils.java
@@ -3,14 +3,15 @@ package dev.creesch.util;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import net.minecraft.component.type.ItemEnchantmentsComponent;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.text.HoverEvent;
-import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableTextContent;
-import net.minecraft.util.Language;
+import net.minecraft.core.Holder;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 
 public class ClientTranslationUtils {
 
@@ -20,7 +21,7 @@ public class ClientTranslationUtils {
      * @param text The Text object to process.
      * @return A map where keys are translation keys and values are the corresponding translations.
      */
-    public static Map<String, String> extractTranslations(Text text) {
+    public static Map<String, String> extractTranslations(Component text) {
         Map<String, String> translations = new HashMap<>();
         collectTranslationKeys(text, translations);
 
@@ -31,20 +32,20 @@ public class ClientTranslationUtils {
     }
 
     private static void collectTranslationKeys(
-        Text text,
+        Component text,
         Map<String, String> keys
     ) {
         if (
-            text.getContent() instanceof
-                TranslatableTextContent translatableContent
+            text.getContents() instanceof
+                TranslatableContents translatableContent
         ) {
             String key = translatableContent.getKey();
             keys.putIfAbsent(key, null);
 
             // Process arguments of the translation
             for (Object arg : translatableContent.getArgs()) {
-                if (arg instanceof Text nestedText) {
-                    collectTranslationKeys(nestedText, keys); // Recursively handle nested Text
+                if (arg instanceof Component nestedText) {
+                    collectTranslationKeys(nestedText, keys); // Recursively handle nested Component
                 } else if (arg instanceof String stringArg) {
                     keys.putIfAbsent(stringArg, null); // Treat plain strings as potential keys. Highly unlikely to ever happen, maybe impossible? Doesn't hurt to account for it.
                 }
@@ -52,7 +53,7 @@ public class ClientTranslationUtils {
         }
 
         // Collect keys from siblings (e.g., appended text)
-        for (Text sibling : text.getSiblings()) {
+        for (Component sibling : text.getSiblings()) {
             collectTranslationKeys(sibling, keys);
         }
 
@@ -63,7 +64,7 @@ public class ClientTranslationUtils {
         }
 
         // Handle different hover event types
-        if (hoverEvent instanceof HoverEvent.ShowText(Text value)) {
+        if (hoverEvent instanceof HoverEvent.ShowText(Component value)) {
             if (value != null) {
                 collectTranslationKeys(value, keys);
             }
@@ -72,16 +73,16 @@ public class ClientTranslationUtils {
         if (
             hoverEvent instanceof
                 HoverEvent.ShowEntity(
-                    HoverEvent.EntityContent hoverEventEntityContent
+                    HoverEvent.EntityTooltipInfo hoverEventEntityContent
                 )
         ) {
             if (hoverEventEntityContent != null) {
                 // Collect entity type translation key (e.g., "entity.minecraft.player")
                 String entityKey =
-                    hoverEventEntityContent.entityType.getTranslationKey();
+                    hoverEventEntityContent.type.getDescriptionId();
                 keys.putIfAbsent(entityKey, null);
 
-                Optional<Text> entityName = hoverEventEntityContent.name;
+                Optional<Component> entityName = hoverEventEntityContent.name;
                 entityName.ifPresent((value) ->
                     collectTranslationKeys(value, keys)
                 );
@@ -89,18 +90,19 @@ public class ClientTranslationUtils {
         }
 
         // Collect translation keys from show_item hover events
-        if (hoverEvent instanceof HoverEvent.ShowItem(ItemStack itemStack)) {
+        if (
+            hoverEvent instanceof
+                HoverEvent.ShowItem(ItemStackTemplate itemTemplate)
+        ) {
+            ItemStack itemStack = itemTemplate.create();
             // Collect item translation key (e.g., "item.minecraft.bow")
-            String itemKey = itemStack.getItem().getTranslationKey();
+            String itemKey = itemStack.getItem().getDescriptionId();
             keys.putIfAbsent(itemKey, null);
 
             // Collect enchantment translation keys
-            ItemEnchantmentsComponent enchantments =
-                itemStack.getEnchantments();
-            for (RegistryEntry<
-                Enchantment
-            > enchantment : enchantments.getEnchantments()) {
-                Text desc = enchantment.value().description();
+            ItemEnchantments enchantments = itemStack.getEnchantments();
+            for (Holder<Enchantment> enchantment : enchantments.keySet()) {
+                Component desc = enchantment.value().description();
                 collectTranslationKeys(desc, keys);
             }
         }
@@ -109,7 +111,9 @@ public class ClientTranslationUtils {
     private static void populateTranslations(Map<String, String> keys) {
         Language language = Language.getInstance(); // Client-side Language instance
         for (Map.Entry<String, String> entry : keys.entrySet()) {
-            entry.setValue(language.get(entry.getKey(), entry.getKey())); // Fallback to key if translation is missing
+            entry.setValue(
+                language.getOrDefault(entry.getKey(), entry.getKey())
+            ); // Fallback to key if translation is missing
         }
     }
 }

--- a/src/client/java/dev/creesch/util/MinecraftServerIdentifier.java
+++ b/src/client/java/dev/creesch/util/MinecraftServerIdentifier.java
@@ -3,10 +3,10 @@ package dev.creesch.util;
 import dev.creesch.model.WebsocketJsonMessage;
 import java.nio.file.Path;
 import java.util.UUID;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ServerInfo;
-import net.minecraft.server.integrated.IntegratedServer;
-import net.minecraft.util.WorldSavePath;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.world.level.storage.LevelResource;
 
 /**
  * Utility class for identifying Minecraft servers and worlds.
@@ -19,7 +19,7 @@ public class MinecraftServerIdentifier {
      * Should not happen in the current mod setup. But better to account for it.
      * Also allows for sending messages in the future when a user is not connected to a server.
      */
-    private static final MinecraftClient client = MinecraftClient.getInstance();
+    private static final Minecraft client = Minecraft.getInstance();
     private static final WebsocketJsonMessage.ChatServerInfo DISCONNECTED =
         new WebsocketJsonMessage.ChatServerInfo("Disconnected", "disconnected");
 
@@ -39,24 +39,24 @@ public class MinecraftServerIdentifier {
      */
     public static WebsocketJsonMessage.ChatServerInfo getCurrentServerInfo() {
         // World is null, so we can't be on a minecraft server of any kind.
-        if (client.world == null) {
+        if (client.level == null) {
             return DISCONNECTED;
         }
 
         // For single player we can use the levelname for the name.
         // But to ensure a unique identifier we are using the save path as worlds can have the same name.
-        if (client.isInSingleplayer()) {
-            IntegratedServer server = client.getServer();
+        if (client.hasSingleplayerServer()) {
+            IntegratedServer server = client.getSingleplayerServer();
             if (server == null) {
                 return DISCONNECTED;
             }
 
-            String worldName = server.getSaveProperties().getLevelName();
+            String worldName = server.getWorldData().getLevelName();
 
             // To create a unique identifier use the save path as world names are not unique.
             // Use relative path so users can still move minecraft directories to a different location.
-            Path minecraftDir = client.runDirectory.toPath();
-            Path savePath = server.getSavePath(WorldSavePath.ROOT);
+            Path minecraftDir = client.gameDirectory.toPath();
+            Path savePath = server.getWorldPath(LevelResource.ROOT);
             String rawIdentifier = minecraftDir.relativize(savePath).toString();
 
             return new WebsocketJsonMessage.ChatServerInfo(
@@ -64,18 +64,16 @@ public class MinecraftServerIdentifier {
                 UUID.nameUUIDFromBytes(rawIdentifier.getBytes()).toString()
             );
         } else {
-            ServerInfo serverInfo = client.getCurrentServerEntry();
+            ServerData serverInfo = client.getCurrentServer();
             if (serverInfo == null) {
                 return DISCONNECTED;
             }
 
-            // It is very unlikely that label is null for servers. But just in case fall back to the server address.
+            // It is very unlikely that name is null for servers. But just in case fall back to the server address.
             String serverName =
-                serverInfo.label != null
-                    ? serverInfo.label.getString()
-                    : serverInfo.address;
+                serverInfo.name != null ? serverInfo.name : serverInfo.ip;
             String serverIdentifier = UUID.nameUUIDFromBytes(
-                serverInfo.address.getBytes()
+                serverInfo.ip.getBytes()
             ).toString();
             return new WebsocketJsonMessage.ChatServerInfo(
                 serverName,

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,13 +20,13 @@
         "modmenu": ["dev.creesch.config.ModMenuIntegration"]
     },
     "depends": {
-        "fabricloader": ">=0.16.14",
-        "minecraft": "~1.21.8",
-        "java": ">=21",
+        "fabricloader": ">=0.18.6",
+        "minecraft": "~26.1",
+        "java": ">=25",
         "fabric-api": "*",
-        "yet_another_config_lib_v3": ">=3.7.1+1.21.6-fabric"
+        "yet_another_config_lib_v3": ">=3.9.2+26.1-fabric"
     },
     "recommends": {
-        "modmenu": ">=11.0.3"
+        "modmenu": ">=18.0.0-alpha.8"
     }
 }


### PR DESCRIPTION
Migrates the mod from Minecraft 1.21.11 to 26.1.2. This is not a routine bump — the Fabric ecosystem switched to Mojang (official) mappings for MC 26.x, so every `net.minecraft.*` reference had to be translated from yarn names, and the Loom build pipeline changed shape.

Build changes
- Java 21 → 25
- Dropped yarn mappings — Loom 1.16 defaults to Mojang mappings
- Removed the remapJar step; shadowJar now produces the final artifact directly
- sqlite-jdbc moved from Loom's include (JIJ) to the shadow configuration, with a minimize exclusion so its reflection-loaded driver classes survive
- `fabric.mod.json` dependency ranges updated