### PR TITLE
Handle abrupt websocket closure gracefully on shutdown

### DIFF
--- a/src/client/java/dev/creesch/WebInterface.java
+++ b/src/client/java/dev/creesch/WebInterface.java
@@ -13,6 +13,7 @@ import io.javalin.http.staticfiles.Location;
 import io.javalin.websocket.WsCloseStatus;
 import io.javalin.websocket.WsContext;
 import io.javalin.websocket.WsMessageContext;
+import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -294,7 +295,16 @@ public class WebInterface {
             ws.onMessage((ctx) -> handleReceivedMessages(ctx));
 
             ws.onError((ctx) -> {
-                LOGGER.error("WebSocket error: ", ctx.error());
+                // A closed channel only means the connection was torn down abruptly,
+                // for example when the game exits while a browser is still connected.
+                if (ctx.error() instanceof ClosedChannelException) {
+                    LOGGER.debug(
+                        "WebSocket channel closed abruptly: {}",
+                        ctx.session.getRemoteSocketAddress()
+                    );
+                } else {
+                    LOGGER.error("WebSocket error: ", ctx.error());
+                }
                 removeConnection(ctx);
             });
         });
@@ -352,14 +362,22 @@ public class WebInterface {
      * @param ctx The WebSocket context to remove.
      */
     private void removeConnection(WsContext ctx) {
-        connections.remove(ctx);
+        // Both onError and onClose can fire for the same connection.
+        // Only the call that actually removes it may decrement the counter,
+        // otherwise the shutdown wait below could be released too early.
+        boolean removed = connections.remove(ctx);
+        if (!removed) {
+            return;
+        }
 
-        if (shutdownInitiated.get()) {
+        if (!shutdownInitiated.get()) {
+            return;
+        }
+
+        synchronized (connectionsToClose) {
             int remaining = connectionsToClose.decrementAndGet();
-            synchronized (connectionsToClose) {
-                if (remaining == 0) {
-                    connectionsToClose.notifyAll();
-                }
+            if (remaining == 0) {
+                connectionsToClose.notifyAll();
             }
         }
     }


### PR DESCRIPTION
Closing the game while a browser was still connected logged a `ClosedChannelException` stack trace at ERROR level. The close handshake initiated during shutdown races with the channel teardown, so Jetty reports the resulting EOF as an error even though nothing went wrong. Log this case at debug level instead.

Also guard the shutdown connection counter against double decrements, since both onError and onClose can fire for the same connection.

Fixes #224